### PR TITLE
_scripts: fix check for formatted go code

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -12,5 +12,5 @@ go mod tidy
 # https://github.com/golang/go/issues/27868#issuecomment-431413621
 go list all > /dev/null
 
-if [[ -n $CHECK_GOFMT ]]; then diff <(echo -n) <(gofmt -d .); fi
+diff <(echo -n) <(gofmt -d $(git ls-files '**/*.go' '*.go' | grep -v cmd/govim/internal))
 test -z "$(git status --porcelain)" || (git status; git diff; false)


### PR DESCRIPTION
We don't need it to be environment-variable driven for now