### PR TITLE
govim: refactor to have an explicit event queue

### DIFF
--- a/channel_cmds.go
+++ b/channel_cmds.go
@@ -1,0 +1,151 @@
+package govim
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type chanErrHandler func(chan callbackResp, error) error
+type chanValueErrHandler func(chan callbackResp, error) (json.RawMessage, error)
+
+func handleChannelError(format string, args ...interface{}) func(chan callbackResp, error) error {
+	f := handleChannelValueAndError(format, args...)
+	return func(ch chan callbackResp, err error) error {
+		_, err = f(ch, err)
+		return err
+	}
+}
+
+func handleChannelValueAndError(format string, args ...interface{}) func(chan callbackResp, error) (json.RawMessage, error) {
+	args = append([]interface{}{}, args...)
+	return func(ch chan callbackResp, err error) (json.RawMessage, error) {
+		resp := <-ch
+		if resp.errString != "" {
+			args = append(args, resp.errString)
+			return nil, fmt.Errorf(format, args...)
+		}
+		return resp.val, nil
+	}
+}
+
+// ChannelRedraw implements Govim.ChannelRedraw
+func (g *govimImpl) ChannelRedraw(force bool) error {
+	f := handleChannelError(channelRedrawErrMsg, force)
+	return g.channelRedrawImpl(f, force)
+}
+
+const channelRedrawErrMsg = "failed to redraw (force = %v) in Vim: %v"
+
+func (g *govimImpl) channelRedrawImpl(f chanErrHandler, force bool) error {
+	<-g.loaded
+	g.Logf("ChannelRedraw: %v\n", force)
+	var sForce string
+	if force {
+		sForce = "force"
+	}
+	var err error
+	var ch chan callbackResp
+	err = g.DoProto(func() {
+		ch = g.callCallback("redraw", sForce)
+	})
+	return f(ch, err)
+}
+
+// ChannelEx implements Govim.ChannelEx
+func (g *govimImpl) ChannelEx(expr string) error {
+	f := handleChannelError(channelExErrMsg, expr)
+	return g.channelExImpl(f, expr)
+}
+
+const channelExErrMsg = "failed to ex(%v) in Vim: %v"
+
+func (g *govimImpl) channelExImpl(f chanErrHandler, expr string) error {
+	<-g.loaded
+	g.Logf("ChannelEx: %v\n", expr)
+	var err error
+	var ch chan callbackResp
+	err = g.DoProto(func() {
+		ch = g.callCallback("ex", expr)
+	})
+	return f(ch, err)
+}
+
+// ChannelEx implements Govim.ChannelNormal
+func (g *govimImpl) ChannelNormal(expr string) error {
+	f := handleChannelError(channelNormalErrMsg, expr)
+	return g.channelNormalImpl(f, expr)
+}
+
+const channelNormalErrMsg = "failed to normal(%v) in Vim: %v"
+
+func (g *govimImpl) channelNormalImpl(f chanErrHandler, expr string) error {
+	<-g.loaded
+	g.Logf("ChannelNormal: %v\n", expr)
+	var err error
+	var ch chan callbackResp
+	err = g.DoProto(func() {
+		ch = g.callCallback("normal", expr)
+	})
+	return f(ch, err)
+}
+
+// ChannelExpr implements Govim.ChannelExpr
+func (g *govimImpl) ChannelExpr(expr string) (json.RawMessage, error) {
+	f := handleChannelValueAndError(channelExprErrMsg, expr)
+	return g.channelExprImpl(f, expr)
+}
+
+const channelExprErrMsg = "failed to expr(%v) in Vim: %v"
+
+func (g *govimImpl) channelExprImpl(f chanValueErrHandler, expr string) (json.RawMessage, error) {
+	<-g.loaded
+	g.Logf("ChannelExpr: %v\n", expr)
+	var err error
+	var ch chan callbackResp
+	err = g.DoProto(func() {
+		ch = g.callCallback("expr", expr)
+	})
+	return f(ch, err)
+}
+
+// ChannelCall implements Govim.ChannelCall
+func (g *govimImpl) ChannelCall(fn string, args ...interface{}) (json.RawMessage, error) {
+	f := handleChannelValueAndError(channelCallErrMsg, fn, args)
+	return g.channelCallImpl(f, fn, args...)
+}
+
+const channelCallErrMsg = "failed to call(%v) in Vim: %v"
+
+func (g *govimImpl) channelCallImpl(f chanValueErrHandler, fn string, args ...interface{}) (json.RawMessage, error) {
+	<-g.loaded
+	args = append([]interface{}{fn}, args...)
+	g.Logf("ChannelCall: %v\n", args)
+	var err error
+	var ch chan callbackResp
+	err = g.DoProto(func() {
+		ch = g.callCallback("call", args...)
+	})
+	return f(ch, err)
+}
+
+func (g *govimImpl) DoProto(f func()) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch r := r.(type) {
+			case errProto:
+				if r.underlying == io.EOF {
+					g.Logf("closing connection\n")
+					return
+				}
+				err = r
+			case error:
+				err = r
+			default:
+				panic(r)
+			}
+		}
+	}()
+	f()
+	return
+}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -6,37 +6,37 @@ import (
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 )
 
-var _ protocol.Client = (*driver)(nil)
+var _ protocol.Client = (*govimplugin)(nil)
 
-func (d *driver) ShowMessage(context.Context, *protocol.ShowMessageParams) error {
+func (g *govimplugin) ShowMessage(context.Context, *protocol.ShowMessageParams) error {
 	panic("not implemented yet")
 }
-func (d *driver) ShowMessageRequest(context.Context, *protocol.ShowMessageRequestParams) (*protocol.MessageActionItem, error) {
+func (g *govimplugin) ShowMessageRequest(context.Context, *protocol.ShowMessageRequestParams) (*protocol.MessageActionItem, error) {
 	panic("not implemented yet")
 }
-func (d *driver) LogMessage(context.Context, *protocol.LogMessageParams) error {
+func (g *govimplugin) LogMessage(context.Context, *protocol.LogMessageParams) error {
 	panic("not implemented yet")
 }
-func (d *driver) Telemetry(context.Context, interface{}) error {
+func (g *govimplugin) Telemetry(context.Context, interface{}) error {
 	panic("not implemented yet")
 }
-func (d *driver) RegisterCapability(context.Context, *protocol.RegistrationParams) error {
+func (g *govimplugin) RegisterCapability(context.Context, *protocol.RegistrationParams) error {
 	panic("not implemented yet")
 }
-func (d *driver) UnregisterCapability(context.Context, *protocol.UnregistrationParams) error {
+func (g *govimplugin) UnregisterCapability(context.Context, *protocol.UnregistrationParams) error {
 	panic("not implemented yet")
 }
-func (d *driver) WorkspaceFolders(context.Context) ([]protocol.WorkspaceFolder, error) {
+func (g *govimplugin) WorkspaceFolders(context.Context) ([]protocol.WorkspaceFolder, error) {
 	panic("not implemented yet")
 }
-func (d *driver) Configuration(context.Context, *protocol.ConfigurationParams) ([]interface{}, error) {
+func (g *govimplugin) Configuration(context.Context, *protocol.ConfigurationParams) ([]interface{}, error) {
 	panic("not implemented yet")
 }
-func (d *driver) ApplyEdit(context.Context, *protocol.ApplyWorkspaceEditParams) (bool, error) {
+func (g *govimplugin) ApplyEdit(context.Context, *protocol.ApplyWorkspaceEditParams) (bool, error) {
 	panic("not implemented yet")
 }
 
-func (d *driver) PublishDiagnostics(ctxt context.Context, params *protocol.PublishDiagnosticsParams) error {
-	d.Logf("PublishDiagnostics callback: %v", params)
+func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.PublishDiagnosticsParams) error {
+	g.Logf("PublishDiagnostics callback: %v", params)
 	return nil
 }

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -30,7 +30,7 @@ func TestScripts(t *testing.T) {
 			Dir: "testdata",
 			Setup: func(e *testscript.Env) error {
 				wg.Add(1)
-				d := newDriver()
+				d := newplugin()
 				td, err := testdriver.NewTestDriver(filepath.Base(e.WorkDir), e, errCh, d)
 				if err != nil {
 					t.Fatalf("failed to create new driver: %v", err)

--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -12,13 +12,13 @@ import (
 // fetchCurrentBufferInfo is a helper function to snapshot the current buffer
 // information from Vim. This helper method should only be used with methods
 // responsible for updating d.buffers
-func (d *driver) fetchCurrentBufferInfo() (*types.Buffer, error) {
+func (v *vimstate) fetchCurrentBufferInfo() (*types.Buffer, error) {
 	var buf struct {
 		Num      int
 		Name     string
 		Contents string
 	}
-	expr := d.ChannelExpr(`{"Num": bufnr(""), "Name": expand('%:p'), "Contents": join(getline(0, "$"), "\n")}`)
+	expr := v.ChannelExpr(`{"Num": bufnr(""), "Name": expand('%:p'), "Contents": join(getline(0, "$"), "\n")}`)
 	if err := json.Unmarshal(expr, &buf); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal current buffer info: %v", err)
 	}
@@ -30,18 +30,18 @@ func (d *driver) fetchCurrentBufferInfo() (*types.Buffer, error) {
 	return res, nil
 }
 
-func (d *driver) cursorPos() (b *types.Buffer, p types.Point, err error) {
+func (v *vimstate) cursorPos() (b *types.Buffer, p types.Point, err error) {
 	var pos struct {
 		BufNum int `json:"bufnum"`
 		Line   int `json:"line"`
 		Col    int `json:"col"`
 	}
-	expr := d.ChannelExpr(`{"bufnum": bufnr(""), "line": line("."), "col": col(".")}`)
+	expr := v.ChannelExpr(`{"bufnum": bufnr(""), "line": line("."), "col": col(".")}`)
 	if err = json.Unmarshal(expr, &pos); err != nil {
 		err = fmt.Errorf("failed to unmarshal current cursor position info: %v", err)
 		return
 	}
-	b, ok := d.buffers[pos.BufNum]
+	b, ok := v.buffers[pos.BufNum]
 	if !ok {
 		err = fmt.Errorf("failed to resolve buffer %v", pos.BufNum)
 	}
@@ -49,18 +49,18 @@ func (d *driver) cursorPos() (b *types.Buffer, p types.Point, err error) {
 	return
 }
 
-func (d *driver) mousePos() (b *types.Buffer, p types.Point, err error) {
+func (v *vimstate) mousePos() (b *types.Buffer, p types.Point, err error) {
 	var pos struct {
 		BufNum int `json:"bufnum"`
 		Line   int `json:"line"`
 		Col    int `json:"col"`
 	}
-	expr := d.ChannelExpr(`{"bufnum": v:beval_bufnr, "line": v:beval_lnum, "col": v:beval_col}`)
+	expr := v.ChannelExpr(`{"bufnum": v:beval_bufnr, "line": v:beval_lnum, "col": v:beval_col}`)
 	if err = json.Unmarshal(expr, &pos); err != nil {
 		err = fmt.Errorf("failed to unmarshal current mouse position info: %v", err)
 		return
 	}
-	b, ok := d.buffers[pos.BufNum]
+	b, ok := v.buffers[pos.BufNum]
 	if !ok {
 		err = fmt.Errorf("failed to resolve buffer %v", pos.BufNum)
 	}

--- a/command.go
+++ b/command.go
@@ -1,0 +1,160 @@
+package govim
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type CommandFlags struct {
+	Line1 *int
+	Line2 *int
+	Range *int
+	Count *int
+	Bang  *bool
+	Reg   *string
+}
+
+func (c *CommandFlags) UnmarshalJSON(b []byte) error {
+	var v struct {
+		Line1 *int    `json:"line1"`
+		Line2 *int    `json:"line2"`
+		Range *int    `json:"range"`
+		Count *int    `json:"count"`
+		Bang  *string `json:"bang"`
+		Reg   *string `json:"reg"`
+	}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	c.Line1 = v.Line1
+	c.Line2 = v.Line2
+	c.Range = v.Range
+	c.Count = v.Count
+	if v.Bang != nil {
+		b := *v.Bang == "!"
+		c.Bang = &b
+	}
+
+	return nil
+}
+
+type CommAttr interface {
+	fmt.Stringer
+	isCommAttr()
+}
+
+type GenAttr uint
+
+func (g GenAttr) isCommAttr() {}
+
+//go:generate gobin -m -run golang.org/x/tools/cmd/stringer -type=GenAttr -linecomment -output gen_genattr_stringer.go
+
+const (
+	AttrBang     GenAttr = iota // -bang
+	AttrBar                     // -bar
+	AttrRegister                // -register
+	AttrBuffer                  // -buffer
+)
+
+type Complete uint
+
+func (c Complete) isCommAttr() {}
+
+//go:generate gobin -m -run golang.org/x/tools/cmd/stringer -type=Complete -linecomment -output gen_complete_stringer.go
+
+const (
+	CompleteArglist      Complete = iota // -complete=arglist
+	CompleteAugroup                      // -complete=augroup
+	CompleteBuffer                       // -complete=buffer
+	CompleteBehave                       // -complete=behave
+	CompleteColor                        // -complete=color
+	CompleteCommand                      // -complete=command
+	CompleteCompiler                     // -complete=compiler
+	CompleteCscope                       // -complete=cscope
+	CompleteDir                          // -complete=dir
+	CompleteEnvironment                  // -complete=environment
+	CompleteEvent                        // -complete=event
+	CompleteExpression                   // -complete=expression
+	CompleteFile                         // -complete=file
+	CompleteFileInPath                   // -complete=file_in_path
+	CompleteFiletype                     // -complete=filetype
+	CompleteFunction                     // -complete=function
+	CompleteHelp                         // -complete=help
+	CompleteHighlight                    // -complete=highlight
+	CompleteHistory                      // -complete=history
+	CompleteLocale                       // -complete=locale
+	CompleteMapclear                     // -complete=mapclear
+	CompleteMapping                      // -complete=mapping
+	CompleteMenu                         // -complete=menu
+	CompleteMessages                     // -complete=messages
+	CompleteOption                       // -complete=option
+	CompletePackadd                      // -complete=packadd
+	CompleteShellCmd                     // -complete=shellcmd
+	CompleteSign                         // -complete=sign
+	CompleteSyntax                       // -complete=syntax
+	CompleteSyntime                      // -complete=syntime
+	CompleteTag                          // -complete=tag
+	CompleteTagListFiles                 // -complete=tag_listfiles
+	CompleteUser                         // -complete=user
+	CompleteVar                          // -complete=var
+)
+
+type CompleteCustom string
+
+func (c CompleteCustom) isCommAttr() {}
+
+func (c CompleteCustom) String() string {
+	return "-complete=custom," + string(c)
+}
+
+type CompleteCustomList string
+
+func (c CompleteCustomList) isCommAttr() {}
+
+func (c CompleteCustomList) String() string {
+	return "-complete=customlist," + string(c)
+}
+
+type RangeN int
+
+func (r RangeN) isCommAttr() {}
+
+func (r RangeN) String() string {
+	return strconv.Itoa(int(r))
+}
+
+type CountN int
+
+func (c CountN) isCommAttr() {}
+
+func (c CountN) String() string {
+	return strconv.Itoa(int(c))
+}
+
+type Range uint
+
+func (r Range) isCommAttr() {}
+
+//go:generate gobin -m -run golang.org/x/tools/cmd/stringer -type=Range -linecomment -output gen_range_stringer.go
+
+const (
+	RangeLine Range = iota // -range
+	RangeFile              // -range=%
+)
+
+type NArgs uint
+
+func (n NArgs) isCommAttr() {}
+
+//go:generate gobin -m -run golang.org/x/tools/cmd/stringer -type=NArgs -linecomment -output gen_nargs_stringer.go
+
+const (
+	NArgs0          NArgs = iota // -nargs=0
+	NArgs1                       // -nargs=1
+	NArgsZeroOrMore              // -nargs=*
+	NArgsZeroOrOne               // -nargs=?
+	NArgsOneOrMore               // -nargs=+
+)

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -124,6 +124,11 @@ function s:define(channel, msg)
       let F= function(l:fn, a:msg[3:-1])
       let l:res = F()
       call add(l:resp[2], l:res)
+    elseif a:msg[1] == "error"
+      let l:msg = a:msg[2]
+      " this is an async call from the client
+      echoerr l:msg
+      return
     else
       throw "unknown callback function type ".a:msg[1]
     endif

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -25,7 +25,7 @@ import (
 type TestDriver struct {
 	govimListener  net.Listener
 	driverListener net.Listener
-	govim          *govim.Govim
+	govim          govim.Govim
 
 	cmd *exec.Cmd
 
@@ -156,7 +156,7 @@ func (d *TestDriver) listenGovim() error {
 	if err != nil {
 		return fmt.Errorf("failed to accept connection on %v: %v", d.govimListener.Addr(), err)
 	}
-	g, err := govim.NewGoVim(d.plugin, conn, conn, ioutil.Discard)
+	g, err := govim.NewGovim(d.plugin, conn, conn, ioutil.Discard)
 	if err != nil {
 		return fmt.Errorf("failed to create govim: %v", err)
 	}
@@ -378,16 +378,16 @@ type signallingPlugin struct {
 	initDone chan bool
 }
 
-func newSignallingPlugin(p govim.Plugin) signallingPlugin {
+func newSignallingPlugin(g govim.Plugin) signallingPlugin {
 	return signallingPlugin{
-		u:        p,
+		u:        g,
 		initDone: make(chan bool),
 	}
 }
 
-func (s signallingPlugin) Init(g *govim.Govim) error {
+func (s signallingPlugin) Init(d govim.Govim) error {
 	defer close(s.initDone)
-	return s.u.Init(g)
+	return s.u.Init(d)
 }
 
 func (s signallingPlugin) Shutdown() error {

--- a/userq.go
+++ b/userq.go
@@ -1,0 +1,75 @@
+package govim
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type userQInst struct {
+	*govimImpl
+}
+
+var _ Govim = userQInst{}
+
+func (u userQInst) ChannelRedraw(force bool) error {
+	f := u.handleUserQError(channelRedrawErrMsg, force)
+	return u.govimImpl.channelRedrawImpl(f, force)
+}
+
+func (u userQInst) ChannelEx(expr string) error {
+	f := u.handleUserQError(channelExErrMsg, expr)
+	return u.govimImpl.channelExImpl(f, expr)
+}
+
+func (u userQInst) ChannelNormal(normalpr string) error {
+	f := u.handleUserQError(channelNormalErrMsg, normalpr)
+	return u.govimImpl.channelNormalImpl(f, normalpr)
+}
+
+func (u userQInst) ChannelExpr(exprpr string) (json.RawMessage, error) {
+	f := u.handleUserQValueAndError(channelExprErrMsg, exprpr)
+	return u.govimImpl.channelExprImpl(f, exprpr)
+}
+
+func (u userQInst) ChannelCall(fn string, args ...interface{}) (json.RawMessage, error) {
+	f := u.handleUserQValueAndError(channelCallErrMsg, fn, args)
+	return u.govimImpl.channelCallImpl(f, fn, args...)
+}
+
+func (u userQInst) handleUserQError(format string, args ...interface{}) func(chan callbackResp, error) error {
+	f := u.handleUserQValueAndError(format, args...)
+	return func(ch chan callbackResp, err error) error {
+		_, err = f(ch, err)
+		return err
+	}
+}
+
+func (u userQInst) Sync() Govim {
+	return u
+}
+
+func (u userQInst) handleUserQValueAndError(format string, args ...interface{}) func(chan callbackResp, error) (json.RawMessage, error) {
+	args = append([]interface{}{}, args...)
+	return func(ch chan callbackResp, err error) (json.RawMessage, error) {
+		if err != nil {
+			return nil, err
+		}
+		var resp callbackResp
+	WaitForResp:
+		for {
+			select {
+			case resp = <-ch:
+				break WaitForResp
+			case u.flushEvents <- struct{}{}:
+				// We have handed over to the eventQ
+				// We need to unblock before we can proceed
+				<-u.flushEvents
+			}
+		}
+		if resp.errString != "" {
+			args = append(args, resp.errString)
+			return nil, fmt.Errorf(format, args...)
+		}
+		return resp.val, nil
+	}
+}

--- a/viewport.go
+++ b/viewport.go
@@ -13,7 +13,7 @@ const (
 
 // SubOnViewportChange creates a subscription to the OnViewportChange event
 // exposed by Govim
-func (g *Govim) SubOnViewportChange(f func(Viewport)) *OnViewportChangeSub {
+func (g *govimImpl) SubOnViewportChange(f func(Viewport)) *OnViewportChangeSub {
 	res := &OnViewportChangeSub{f: f}
 	g.onViewportChangeSubsLock.Lock()
 	g.onViewportChangeSubs = append(g.onViewportChangeSubs, res)
@@ -23,7 +23,7 @@ func (g *Govim) SubOnViewportChange(f func(Viewport)) *OnViewportChangeSub {
 
 // UnsubOnViewportChange removes a subscription to the OnViewportChange event.
 // It panics if sub is not an active subscription.
-func (g *Govim) UnsubOnViewportChange(sub *OnViewportChangeSub) {
+func (g *govimImpl) UnsubOnViewportChange(sub *OnViewportChangeSub) {
 	g.onViewportChangeSubsLock.Lock()
 	defer g.onViewportChangeSubsLock.Unlock()
 	for i, s := range g.onViewportChangeSubs {
@@ -35,7 +35,7 @@ func (g *Govim) UnsubOnViewportChange(sub *OnViewportChangeSub) {
 	panic(fmt.Errorf("did not find subscription"))
 }
 
-func (g *Govim) ToggleOnViewportChange() {
+func (g *govimImpl) ToggleOnViewportChange() {
 	select {
 	case <-g.tomb.Dying():
 		// we are already dying, nothing to do
@@ -50,7 +50,7 @@ type OnViewportChangeSub struct {
 	f func(Viewport)
 }
 
-func (g *Govim) onViewportChange(args ...json.RawMessage) (interface{}, error) {
+func (g *govimImpl) onViewportChange(args ...json.RawMessage) (interface{}, error) {
 	var r Viewport
 	g.decodeJSON(args[0], &r)
 	g.viewportLock.Lock()
@@ -93,7 +93,7 @@ type WinInfo struct {
 }
 
 // Viewport returns the active Vim viewport
-func (g *Govim) Viewport() Viewport {
+func (g *govimImpl) Viewport() Viewport {
 	var res Viewport
 	g.viewportLock.Lock()
 	res = g.currViewport.dup()


### PR DESCRIPTION
Some calls from govim to Vim will result in events. If such a call
happens in a function/command callback, then we will deadlock because
the events will not be able to "fire".

Instead we split out a separate event queue. This allows calls made from
govim to Vim to result in events and for that event queue to be flushed
before we return to the caller.