### PR TITLE
govim: initial definition of shutdown sequence

### DIFF
--- a/channel_cmds.go
+++ b/channel_cmds.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"gopkg.in/tomb.v2"
 )
 
 func (g *govimImpl) handleChannelError(ch unscheduledCallback, err error, format string, args ...interface{}) error {
@@ -20,7 +18,7 @@ func (g *govimImpl) handleChannelValueAndError(ch unscheduledCallback, err error
 	args = append([]interface{}{}, args...)
 	select {
 	case <-g.tomb.Dying():
-		return nil, tomb.ErrDying
+		panic(ErrShuttingDown)
 	case resp := <-ch:
 		if resp.errString != "" {
 			args = append(args, resp.errString)
@@ -126,6 +124,9 @@ func (g *govimImpl) DoProto(f func() error) (err error) {
 				}
 				err = r
 			case error:
+				if r == ErrShuttingDown {
+					panic(r)
+				}
 				err = r
 			default:
 				panic(r)

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -19,6 +19,10 @@ func (g *govimplugin) ShowMessageRequest(context.Context, *protocol.ShowMessageR
 }
 func (g *govimplugin) LogMessage(ctxt context.Context, params *protocol.LogMessageParams) error {
 	g.logGoplsClientf("LogMessage callback: %v", pretty.Sprint(params))
+	switch params.Type {
+	case protocol.Error:
+		g.ChannelExf("echohl ErrorMsg | echom %q | echohl None", params.Message)
+	}
 	return nil
 }
 func (g *govimplugin) Telemetry(context.Context, interface{}) error {

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -72,6 +72,14 @@ function s:callbackAutoCommand(name, exprs)
   return l:resp[1]
 endfunction
 
+function s:doShutdown()
+  if s:govim_status != "initcomplete"
+    " TODO anything to do here other than return?
+    return
+  endif
+  call ch_close(s:channel)
+endfunction
+
 function s:buildCurrentViewport()
   let l:currTabNr = tabpagenr()
   let l:currWinNr = winnr()
@@ -320,3 +328,5 @@ else
   let job = job_start(start, opts)
   let s:channel = job_getchannel(job)
 endif
+
+au VimLeave * call s:doShutdown()

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -203,7 +203,14 @@ func (d *TestDriver) Close() {
 	select {
 	case <-d.doneQuitVim:
 	default:
-		d.govim.ChannelEx("qall!")
+		func() {
+			defer func() {
+				if r := recover(); r != nil && r != govim.ErrShuttingDown {
+					panic(r)
+				}
+			}()
+			d.govim.ChannelEx("qall!")
+		}()
 		<-d.doneQuitVim
 	}
 	select {


### PR DESCRIPTION
Because Vim and gopls are both sources of events as far as govim is
concerned, we effectively have a race when it comes to shutdown. Vim
will always be the one initiating the shutdown, but that notice can
happen at exactly the same time as receiving a message from gopls that
requires us to do something in Vim.

Hence shutdown is initiated by Vim by closing the channel. This allows
the read loop in govim to exit cleanly.

But at this point writes to the connection (off the back of events from
gopls for example) will fail.

Therefore, we define that any error whilst attempting to write to the
connection is indicative of the fact that we (govim) are shutting down.

When we detect we are shutting down, we panic with a known error. This
allows us to cleanly and quickly unwind in a well defined manner.