### PR TITLE
govim: move base config from govim.vim to test.vim

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -9,8 +9,6 @@ let s:plugindir = expand(expand("<sfile>:p:h:h"))
 let s:govim_status = "loading"
 let s:loadStatusCallbacks = []
 
-set mouse=a
-set ttymouse=sgr
 set balloondelay=250
 set ballooneval
 set balloonevalterm

--- a/testdriver/test.vim
+++ b/testdriver/test.vim
@@ -1,3 +1,5 @@
+set mouse=a
+set ttymouse=xterm2
 set nocompatible
 set nobackup
 set nowritebackup


### PR DESCRIPTION
test.vim will continue to represent the minimal .vimrc required to use
govim