### PR TITLE
README: make pointer to minimal.vimrc more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Install `govim` via:
 * [Vundle](https://github.com/VundleVim/Vundle.vim)
   * `Plugin 'myitcv/govim'`
 
-If necessary, setup a [minimal `.vimrc`](minimal.vimrc).
+You might need some `.vimrc` settings to get all features working: see the [minimal `.vimrc`](minimal.vimrc) for more
+details. For more `.vimrc` tips and tricks, see [here](https://github.com/myitcv/govim/wiki/vimrc-tips).
 
 ### What can `govim` do?
 

--- a/minimal.vimrc
+++ b/minimal.vimrc
@@ -13,5 +13,8 @@ set mouse=a
 "
 " :help ttymouse
 "
-" for the appropriate setting for your terminal.
-set ttymouse=xterm2
+" for the appropriate setting for your terminal. Note that despite the
+" automated tests using xterm as the terminal, a setting of ttymouse=xterm
+" does not work correctly beyond a certain column number (citation needed)
+" hence we use ttymouse=sgr
+set ttymouse=sgr


### PR DESCRIPTION
* Also include linke to https://github.com/myitcv/govim/wiki/vimrc-tips
* Fix broken ttymouse default