### PR TITLE
issues: request :messages from Vim and log file hint as part of tmpl

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -25,6 +25,15 @@ $ go env
 ### What version/commit of `govim` are you using?
 
 
+### What is the output of `:messages` in Vim?
+
+
+### Do the Vim channel or `govim` log files show anything interesting?
+
+<!-- !! BEWARE THESE LOGFILES CONTAIN FILE CONTENTS !! -->
+
+<!-- The location of the logfiles is given by :messages in Vim -->
+
 
 ### How did you install `govim`?
 


### PR DESCRIPTION
Very often useful messages will be shown by :messages in Vim. But it's
easy to miss such messages. Request the output from that command in the
template in order to prompt the user to consider that output first.

Then also ask for interesting bits from the log files, locations given
by :messages.

Add note of caution that logfiles include file contents.