### PR TITLE
cmd/govim: explicitly use bufname instead of <afile>

### DIFF
--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": expand('<afile>:p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")}`
+	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": fnamemodify(bufname(eval(expand('<abuf>'))),':p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")}`
 )
 
 // currentBufferInfo is a helper function to unmarshal autocmd current


### PR DESCRIPTION
Autocmds like BufReadCmd don't reliably give us <afile> as the filename.
Instead we can use <abuf> and resolve via bufname