### PR TITLE
deps: update to golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307

### DIFF
--- a/cmd/govim/internal/lsp/cache/parse.go
+++ b/cmd/govim/internal/lsp/cache/parse.go
@@ -1,0 +1,269 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/scanner"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/myitcv/govim/cmd/govim/internal/span"
+)
+
+// We use a counting semaphore to limit
+// the number of parallel I/O calls per process.
+var ioLimit = make(chan bool, 20)
+
+// parseFiles reads and parses the Go source files and returns the ASTs
+// of the ones that could be at least partially parsed, along with a
+// list of I/O and parse errors encountered.
+//
+// Because files are scanned in parallel, the token.Pos
+// positions of the resulting ast.Files are not ordered.
+//
+func (imp *importer) parseFiles(filenames []string) ([]*ast.File, []error) {
+	var wg sync.WaitGroup
+	n := len(filenames)
+	parsed := make([]*ast.File, n)
+	errors := make([]error, n)
+	for i, filename := range filenames {
+		if imp.view.Config.Context.Err() != nil {
+			parsed[i] = nil
+			errors[i] = imp.view.Config.Context.Err()
+			continue
+		}
+
+		// First, check if we have already cached an AST for this file.
+		f, err := imp.view.findFile(span.FileURI(filename))
+		if err != nil {
+			parsed[i], errors[i] = nil, err
+		}
+		var fAST *ast.File
+		if f != nil {
+			fAST = f.ast
+		}
+
+		wg.Add(1)
+		go func(i int, filename string) {
+			ioLimit <- true // wait
+
+			if fAST != nil {
+				parsed[i], errors[i] = fAST, nil
+			} else {
+				// We don't have a cached AST for this file.
+				var src []byte
+				// Check for an available overlay.
+				for f, contents := range imp.view.Config.Overlay {
+					if sameFile(f, filename) {
+						src = contents
+					}
+				}
+				var err error
+				// We don't have an overlay, so we must read the file's contents.
+				if src == nil {
+					src, err = ioutil.ReadFile(filename)
+				}
+				if err != nil {
+					parsed[i], errors[i] = nil, err
+				} else {
+					// ParseFile may return both an AST and an error.
+					parsed[i], errors[i] = imp.view.Config.ParseFile(imp.view.Config.Fset, filename, src)
+
+					// Fix any badly parsed parts of the AST.
+					if file := parsed[i]; file != nil {
+						tok := imp.view.Config.Fset.File(file.Pos())
+						imp.view.fix(imp.ctx, parsed[i], tok, src)
+					}
+				}
+			}
+
+			<-ioLimit // signal
+			wg.Done()
+		}(i, filename)
+	}
+	wg.Wait()
+
+	// Eliminate nils, preserving order.
+	var o int
+	for _, f := range parsed {
+		if f != nil {
+			parsed[o] = f
+			o++
+		}
+	}
+	parsed = parsed[:o]
+
+	o = 0
+	for _, err := range errors {
+		if err != nil {
+			errors[o] = err
+			o++
+		}
+	}
+	errors = errors[:o]
+
+	return parsed, errors
+}
+
+// sameFile returns true if x and y have the same basename and denote
+// the same file.
+//
+func sameFile(x, y string) bool {
+	if x == y {
+		// It could be the case that y doesn't exist.
+		// For instance, it may be an overlay file that
+		// hasn't been written to disk. To handle that case
+		// let x == y through. (We added the exact absolute path
+		// string to the CompiledGoFiles list, so the unwritten
+		// overlay case implies x==y.)
+		return true
+	}
+	if strings.EqualFold(filepath.Base(x), filepath.Base(y)) { // (optimisation)
+		if xi, err := os.Stat(x); err == nil {
+			if yi, err := os.Stat(y); err == nil {
+				return os.SameFile(xi, yi)
+			}
+		}
+	}
+	return false
+}
+
+// fix inspects and potentially modifies any *ast.BadStmts or *ast.BadExprs in the AST.
+
+// We attempt to modify the AST such that we can type-check it more effectively.
+func (v *View) fix(ctx context.Context, file *ast.File, tok *token.File, src []byte) {
+	var parent ast.Node
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n := n.(type) {
+		case *ast.BadStmt:
+			if err := v.parseDeferOrGoStmt(n, parent, tok, src); err != nil {
+				v.log.Debugf(ctx, "unable to parse defer or go from *ast.BadStmt: %v", err)
+			}
+			return false
+		default:
+			parent = n
+			return true
+		}
+	})
+}
+
+// parseDeferOrGoStmt tries to parse an *ast.BadStmt into a defer or a go statement.
+//
+// go/parser packages a statement of the form "defer x." as an *ast.BadStmt because
+// it does not include a call expression. This means that go/types skips type-checking
+// this statement entirely, and we can't use the type information when completing.
+// Here, we try to generate a fake *ast.DeferStmt or *ast.GoStmt to put into the AST,
+// instead of the *ast.BadStmt.
+func (v *View) parseDeferOrGoStmt(bad *ast.BadStmt, parent ast.Node, tok *token.File, src []byte) error {
+	// Check if we have a bad statement containing either a "go" or "defer".
+	s := &scanner.Scanner{}
+	s.Init(tok, src, nil, 0)
+
+	var pos token.Pos
+	var tkn token.Token
+	var lit string
+	for {
+		if tkn == token.EOF {
+			return fmt.Errorf("reached the end of the file")
+		}
+		if pos >= bad.From {
+			break
+		}
+		pos, tkn, lit = s.Scan()
+	}
+	var stmt ast.Stmt
+	switch lit {
+	case "defer":
+		stmt = &ast.DeferStmt{
+			Defer: pos,
+		}
+	case "go":
+		stmt = &ast.GoStmt{
+			Go: pos,
+		}
+	default:
+		return fmt.Errorf("no defer or go statement found")
+	}
+
+	// The expression after the "defer" or "go" starts at this position.
+	from, _, _ := s.Scan()
+	var to, curr token.Pos
+FindTo:
+	for {
+		curr, tkn, lit = s.Scan()
+		// TODO(rstambler): This still needs more handling to work correctly.
+		// We encounter a specific issue with code that looks like this:
+		//
+		//      defer x.<>
+		//      y := 1
+		//
+		// In this scenario, we parse it as "defer x.y", which then fails to
+		// type-check, and we don't get completions as expected.
+		switch tkn {
+		case token.COMMENT, token.EOF, token.SEMICOLON, token.DEFINE:
+			break FindTo
+		}
+		// to is the end of expression that should become the Fun part of the call.
+		to = curr
+	}
+	if !from.IsValid() || tok.Offset(from) >= len(src) {
+		return fmt.Errorf("invalid from position")
+	}
+	if !to.IsValid() || tok.Offset(to)+1 >= len(src) {
+		return fmt.Errorf("invalid to position")
+	}
+	exprstr := string(src[tok.Offset(from) : tok.Offset(to)+1])
+	expr, err := parser.ParseExpr(exprstr)
+	if expr == nil {
+		return fmt.Errorf("no expr in %s: %v", exprstr, err)
+	}
+	// parser.ParseExpr returns undefined positions.
+	// Adjust them for the current file.
+	v.offsetPositions(expr, from-1)
+
+	// Package the expression into a fake *ast.CallExpr and re-insert into the function.
+	call := &ast.CallExpr{
+		Fun:    expr,
+		Lparen: to,
+		Rparen: to,
+	}
+	switch stmt := stmt.(type) {
+	case *ast.DeferStmt:
+		stmt.Call = call
+	case *ast.GoStmt:
+		stmt.Call = call
+	}
+	switch parent := parent.(type) {
+	case *ast.BlockStmt:
+		for i, s := range parent.List {
+			if s == bad {
+				parent.List[i] = stmt
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// offsetPositions applies an offset to the positions in an ast.Node.
+// TODO(rstambler): Add more cases here as they become necessary.
+func (v *View) offsetPositions(expr ast.Expr, offset token.Pos) {
+	ast.Inspect(expr, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.Ident:
+			n.NamePos += offset
+			return false
+		default:
+			return true
+		}
+	})
+}

--- a/cmd/govim/internal/lsp/testdata/badstmt/badstmt.go
+++ b/cmd/govim/internal/lsp/testdata/badstmt/badstmt.go
@@ -1,0 +1,10 @@
+package badstmt
+
+import (
+	"github.com/myitcv/govim/cmd/govim/internal/lsp/foo"
+)
+
+func _() {
+	defer foo.F //@complete("F", Foo, IntFoo, StructFoo),diag(" //", "LSP", "function must be invoked in defer statement")
+	go foo.F //@complete("F", Foo, IntFoo, StructFoo)
+}

--- a/cmd/govim/internal/lsp/testdata/bar/bar.go.in
+++ b/cmd/govim/internal/lsp/testdata/bar/bar.go.in
@@ -38,7 +38,7 @@ func _() {
 		Value: Valen //@complete("le", Valentine)
 	}
 	_ = foo.StructFoo{
-		Value:       //@complete(re"$", Valentine, foo, Bar, helper)
+		Value:       //@complete(" //", Valentine, foo, Bar, helper)
 	}
 	_ = foo.StructFoo{
 		Value:       //@complete(" ", Valentine, foo, Bar, helper)

--- a/cmd/govim/internal/lsp/testdata/basiclit/basiclit.go
+++ b/cmd/govim/internal/lsp/testdata/basiclit/basiclit.go
@@ -1,0 +1,13 @@
+package basiclit
+
+func _() {
+	var a int // something for lexical completions
+
+	_ = "hello." //@complete(".")
+
+	_ = 1 //@complete(" //")
+
+	_ = 1. //@complete(".")
+
+	_ = 'a' //@complete("' ")
+}

--- a/cmd/govim/internal/lsp/testdata/baz/baz.go.in
+++ b/cmd/govim/internal/lsp/testdata/baz/baz.go.in
@@ -18,10 +18,10 @@ func Baz() {
 
 func _() {
 	bob := f.StructFoo{Value: 5}
-	if x := bob.           //@complete(re"$", Value)
+	if x := bob.           //@complete(" //", Value)
 	switch true == false {
 		case true:
-			if x := bob.   //@complete(re"$", Value)
+			if x := bob.   //@complete(" //", Value)
 		case false:
 	}
 	if x := bob.Va         //@complete("a", Value)

--- a/cmd/govim/internal/lsp/testdata/comments/comments.go
+++ b/cmd/govim/internal/lsp/testdata/comments/comments.go
@@ -1,0 +1,27 @@
+package comments
+
+var p bool
+
+//@complete(re"$")
+
+func _() {
+	var a int
+
+	switch a {
+	case 1:
+		//@complete(re"$")
+		_ = a
+	}
+
+	var b chan int
+	select {
+	case <-b:
+		//@complete(re"$")
+		_ = b
+	}
+
+	var (
+		//@complete(re"$")
+		_ = a
+	)
+}

--- a/cmd/govim/internal/lsp/testdata/stringlit/stringlit.go.in
+++ b/cmd/govim/internal/lsp/testdata/stringlit/stringlit.go.in
@@ -1,5 +1,0 @@
-package stringlit
-
-func _() {
-	_ := "hello." //@complete(".")
-}

--- a/cmd/govim/internal/lsp/tests/tests.go
+++ b/cmd/govim/internal/lsp/tests/tests.go
@@ -27,8 +27,8 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount     = 75
-	ExpectedDiagnosticsCount     = 16
+	ExpectedCompletionsCount     = 84
+	ExpectedDiagnosticsCount     = 17
 	ExpectedFormatCount          = 4
 	ExpectedDefinitionsCount     = 21
 	ExpectedTypeDefinitionsCount = 2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/myitcv/vbash v0.0.4
 	github.com/rogpeppe/go-internal v1.2.2
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20190424031103-cb2dda6eabdf
+	golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	honnef.co/go/tools v0.0.0-20190315113450-95959eaf5e3c
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190424031103-cb2dda6eabdf h1:Yv3pKbXQqpdhrt53r+Yr1XveoqVgIFTCQdaamSalWwM=
-golang.org/x/tools v0.0.0-20190424031103-cb2dda6eabdf/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307 h1:CEm6sRmRqgYChP5r+2l+WE900F/PMK5AoCCIsSlTmIk=
+golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=


### PR DESCRIPTION
To pick up:

* internal/lsp: handle completion after defer, go statements
* internal/lsp: suppress more completions in comments and literals