### PR TITLE
deps: golang.org/x/tools v0.0.0-20190425221449-0c752f569a3e

### DIFF
--- a/cmd/govim/internal/lsp/cache/check.go
+++ b/cmd/govim/internal/lsp/cache/check.go
@@ -91,7 +91,13 @@ func (v *View) checkMetadata(ctx context.Context, f *File) ([]packages.Error, er
 			if err == nil {
 				err = fmt.Errorf("no packages found for %s", f.filename)
 			}
-			return nil, err
+			// Return this error as a diagnostic to the user.
+			return []packages.Error{
+				{
+					Msg:  err.Error(),
+					Kind: packages.ListError,
+				},
+			}, err
 		}
 		for _, pkg := range pkgs {
 			// If the package comes back with errors from `go list`, don't bother

--- a/cmd/govim/internal/lsp/cache/file.go
+++ b/cmd/govim/internal/lsp/cache/file.go
@@ -89,8 +89,7 @@ func (f *File) GetPackage(ctx context.Context) source.Package {
 	f.view.mu.Lock()
 	defer f.view.mu.Unlock()
 	if f.pkg == nil || len(f.view.contentChanges) > 0 {
-		errs, err := f.view.parse(ctx, f)
-		if err != nil {
+		if errs, err := f.view.parse(ctx, f); err != nil {
 			// Create diagnostics for errors if we are able to.
 			if len(errs) > 0 {
 				return &Package{errors: errs}

--- a/cmd/govim/internal/lsp/snippet/snippet_builder.go
+++ b/cmd/govim/internal/lsp/snippet/snippet_builder.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package snippet implements the specification for the LSP snippet format.
+//
+// Snippets are "tab stop" templates returned as an optional attribute of LSP
+// completion candidates. As the user presses tab, they cycle through a series of
+// tab stops defined in the snippet. Each tab stop can optionally have placeholder
+// text, which can be pre-selected by editors. For a full description of syntax
+// and features, see "Snippet Syntax" at
+// https://microsoft.github.io/language-server-protocol/specification#textDocument_completion.
+//
+// A typical snippet looks like "foo(${1:i int}, ${2:s string})".
+package snippet
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Builder is used to build an LSP snippet piecemeal.
+// The zero value is ready to use. Do not copy a non-zero Builder.
+type Builder struct {
+	// currentTabStop is the index of the previous tab stop. The
+	// next tab stop will be currentTabStop+1.
+	currentTabStop int
+	sb             strings.Builder
+}
+
+// Escape characters defined in https://microsoft.github.io/language-server-protocol/specification#textDocument_completion under "Grammar".
+var replacer = strings.NewReplacer(
+	`\`, `\\`,
+	`}`, `\}`,
+	`$`, `\$`,
+)
+
+func (b *Builder) WriteText(s string) {
+	replacer.WriteString(&b.sb, s)
+}
+
+// WritePlaceholder writes a tab stop and placeholder value to the Builder.
+// The callback style allows for creating nested placeholders. To write an
+// empty tab stop, provide a nil callback.
+func (b *Builder) WritePlaceholder(fn func(*Builder)) {
+	fmt.Fprintf(&b.sb, "${%d", b.nextTabStop())
+	if fn != nil {
+		b.sb.WriteByte(':')
+		fn(b)
+	}
+	b.sb.WriteByte('}')
+}
+
+// In addition to '\', '}', and '$', snippet choices also use '|' and ',' as
+// meta characters, so they must be escaped within the choices.
+var choiceReplacer = strings.NewReplacer(
+	`\`, `\\`,
+	`}`, `\}`,
+	`$`, `\$`,
+	`|`, `\|`,
+	`,`, `\,`,
+)
+
+// WriteChoice writes a tab stop and list of text choices to the Builder.
+// The user's editor will prompt the user to choose one of the choices.
+func (b *Builder) WriteChoice(choices []string) {
+	fmt.Fprintf(&b.sb, "${%d|", b.nextTabStop())
+	for i, c := range choices {
+		if i != 0 {
+			b.sb.WriteByte(',')
+		}
+		choiceReplacer.WriteString(&b.sb, c)
+	}
+	b.sb.WriteString("|}")
+}
+
+// String returns the built snippet string.
+func (b *Builder) String() string {
+	return b.sb.String()
+}
+
+// nextTabStop returns the next tab stop index for a new placeholder.
+func (b *Builder) nextTabStop() int {
+	// Tab stops start from 1, so increment before returning.
+	b.currentTabStop++
+	return b.currentTabStop
+}

--- a/cmd/govim/internal/lsp/source/diagnostics.go
+++ b/cmd/govim/internal/lsp/source/diagnostics.go
@@ -105,7 +105,7 @@ func Diagnostics(ctx context.Context, v View, uri span.URI) (map[span.URI][]Diag
 	v.Logger().Debugf(ctx, "running `go vet` analyses for %s", uri)
 
 	// Type checking and parsing succeeded. Run analyses.
-	runAnalyses(ctx, v, pkg, func(a *analysis.Analyzer, diag analysis.Diagnostic) error {
+	if err := runAnalyses(ctx, v, pkg, func(a *analysis.Analyzer, diag analysis.Diagnostic) error {
 		r := span.NewRange(v.FileSet(), diag.Pos, 0)
 		s, err := r.Span()
 		if err != nil {
@@ -123,7 +123,9 @@ func Diagnostics(ctx context.Context, v View, uri span.URI) (map[span.URI][]Diag
 			Severity: SeverityWarning,
 		})
 		return nil
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	v.Logger().Debugf(ctx, "completed reporting `go vet` analyses for %s", uri)
 

--- a/cmd/govim/internal/span/utf16.go
+++ b/cmd/govim/internal/span/utf16.go
@@ -40,9 +40,6 @@ func ToUTF16Column(p Point, content []byte) (int, error) {
 	start := content[lineOffset:]
 
 	// Now, truncate down to the supplied column.
-	if col > len(start) { // col is 1-indexed
-		return -1, fmt.Errorf("ToUTF16Column: length of line (%v) is less than column (%v)", len(start), col)
-	}
 	start = start[:col]
 	// and count the number of utf16 characters
 	// in theory we could do this by hand more efficiently...
@@ -62,7 +59,7 @@ func FromUTF16Column(p Point, chr int, content []byte) (Point, error) {
 		return p, nil
 	}
 	if p.Offset() >= len(content) {
-		return p, fmt.Errorf("offset (%v) greater than length of content (%v)", p.Offset(), len(content))
+		return p, fmt.Errorf("FromUTF16Column: offset (%v) greater than length of content (%v)", p.Offset(), len(content))
 	}
 	remains := content[p.Offset():]
 	// scan forward the specified number of characters

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/myitcv/vbash v0.0.4
 	github.com/rogpeppe/go-internal v1.2.2
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307
+	golang.org/x/tools v0.0.0-20190425221449-0c752f569a3e
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	honnef.co/go/tools v0.0.0-20190315113450-95959eaf5e3c
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307 h1:CEm6sRmRqgYChP5r+2l+WE900F/PMK5AoCCIsSlTmIk=
-golang.org/x/tools v0.0.0-20190425001055-9e44c1c40307/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190425221449-0c752f569a3e h1:5mlPoW7HPv4bMxGhUKZN7tke/6qpwHokKNQ0mN2bHo4=
+golang.org/x/tools v0.0.0-20190425221449-0c752f569a3e/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=


### PR DESCRIPTION
* internal/lsp: fix utf16 conversion for end of file cursor
* internal/lsp: extensive utf16 tests
* internal/lsp: handle error from runAnalyses
* internal/lsp: fix stuck diagnostic messages
* internal/lsp: return errors when we can't find a package
* internal/lsp: introduce snippet builder object

Fixes #98