### PR TITLE
cmd/govim: enforce the minimum Vim version requirement

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -1,3 +1,8 @@
+if !has("patch-8.1.1158")
+  echoerr "Need at least version v8.1.1158 of Vim; govim will not be loaded"
+  finish
+endif
+
 " TODO we are ignoring windows right now....
 let s:tmpdir = $TMPDIR
 if s:tmpdir == ""


### PR DESCRIPTION
It doesn't seem worth a best-efforts approach to supporting old Vim
versions. We can't make any guarantees about user experience... which is
a bad start.