### PR TITLE
cmd/govim: ensure that we correctly add a newline to end of file

### DIFF
--- a/cmd/govim/testdata/format_on_save_gofmt.txt
+++ b/cmd/govim/testdata/format_on_save_gofmt.txt
@@ -17,6 +17,7 @@ package blah
 const ( x = 5
 y = os.PathSeparator
  )
+
 -- file.go.gofmt --
 package blah
 

--- a/cmd/govim/testdata/format_on_save_goimports.txt
+++ b/cmd/govim/testdata/format_on_save_goimports.txt
@@ -20,6 +20,7 @@ package blah
 const ( x = 5
 y = os.PathSeparator
  )
+
 -- file.go.goimports --
 package blah
 

--- a/cmd/govim/testdata/format_on_save_none.txt
+++ b/cmd/govim/testdata/format_on_save_none.txt
@@ -15,3 +15,4 @@ package blah
 const ( x = 5
 y = os.PathSeparator
  )
+

--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": fnamemodify(bufname(eval(expand('<abuf>'))),':p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")}`
+	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": fnamemodify(bufname(eval(expand('<abuf>'))),':p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")."\n"}`
 )
 
 // currentBufferInfo is a helper function to unmarshal autocmd current


### PR DESCRIPTION
Our method of getting the entire buffer from Vim was failing to add a
trailing (end of file) newline (\n). Hence we were passing the file
contents minus the trailing \n to gopls. Which results in a bug in calls
to Formatting/CodeAction, but is almost certainly also invalid.

You have to go out of your way to avoid writing a trailing \n in Vim,
and for .go files it's almost certainly the case that the user wants to
write one.

We can revisit this more precisely if there is a pressing case for _not_
having a trailing \n.