### PR TITLE
ci: add Neovim Docker support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ env:
     - GO111MODULE=on
     - GOPROXY=https://proxy.golang.org
   matrix:
-    - GO_VERSION=go1.12.4 VIM_VERSION=v8.1.1158 VIM_COMMAND="vim"
-    - GO_VERSION=go1.12.4 VIM_VERSION=v8.1.1158 VIM_COMMAND="xvfb-run -a gvim -f"
-    - GO_VERSION=go1.12.4 VIM_VERSION=v8.1.1222 VIM_COMMAND="vim"
-    - GO_VERSION=go1.12.4 VIM_VERSION=v8.1.1222 VIM_COMMAND="xvfb-run -a gvim -f"
+    - GO_VERSION=go1.12.4 VIM_FLAVOR=vim VERSION=v8.1.1158 VIM_COMMAND="vim"
+    - GO_VERSION=go1.12.4 VIM_FLAVOR=vim VERSION=v8.1.1158 VIM_COMMAND="xvfb-run -a gvim -f"
+    - GO_VERSION=go1.12.4 VIM_FLAVOR=vim VERSION=v8.1.1222 VIM_COMMAND="vim"
+    - GO_VERSION=go1.12.4 VIM_FLAVOR=vim VERSION=v8.1.1222 VIM_COMMAND="xvfb-run -a gvim -f"
 
 # Add this before_install until we have a definitive resolution on
 # https://travis-ci.community/t/files-in-checkout-have-eol-changed-from-lf-to-crlf/349/2
@@ -25,8 +25,8 @@ before_install:
 
 before_install:
   - docker --version
-  - docker pull govim/govim:${GO_VERSION}_${VIM_VERSION}_v1 | tee
-  - cat Dockerfile.user | envsubst '$GO_VERSION,$VIM_VERSION' | docker build -t govim --build-arg USER=$USER --build-arg UID=$UID --build-arg GID=$(id -g $USER) -
+  - docker pull govim/govim:${GO_VERSION}_${VIM_FLAVOR}_${VERSION}_v1 | tee
+  - cat Dockerfile.user | envsubst '$GO_VERSION,$VIM_FLAVOR,$VERSION' | docker build -t govim --build-arg USER=$USER --build-arg UID=$UID --build-arg GID=$(id -g $USER) -
 
 script:
   - ./_scripts/runDockerRun.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,13 +15,3 @@ RUN cd $(mktemp -d) && \
   go get github.com/myitcv/vbash@$VBASHVERSION && \
   GOBIN=/usr/bin go install github.com/myitcv/vbash
 
-ARG VIM_VERSION
-RUN cd /tmp && \
-  git clone https://github.com/vim/vim && \
-  cd vim && \
-  git checkout $VIM_VERSION && \
-  ./configure --prefix=/vim --enable-gui=gtk2 --disable-darwin --disable-selinux --disable-netbeans && \
-  make -j$(nproc --all) install
-
-ENV PATH=/vim/bin:$PATH
-

--- a/Dockerfile.nvim
+++ b/Dockerfile.nvim
@@ -1,0 +1,28 @@
+ARG GO_VERSION
+ARG VBASHVERSION
+FROM govim/govim:base_${GO_VERSION}_${VBASHVERSION}
+
+RUN apt-get update && \
+    apt-get install -y \
+    autoconf \
+    automake \
+    cmake \
+    g++ pkg-config \
+    gettext \
+    libtool \
+    libtool-bin \
+    ninja-build \
+    unzip \
+    && apt-get clean
+
+ARG NEOVIM_VERSION
+RUN cd /tmp && \
+  git clone https://github.com/neovim/neovim && \
+  cd neovim 
+  # && \
+RUN cd /tmp/neovim && \
+  git checkout $NEOVIM_VERSION && \
+  make CMAKE_INSTALL_PREFIX=/neovim && \
+  make install
+
+ENV PATH=/neovim/bin:$PATH

--- a/Dockerfile.user
+++ b/Dockerfile.user
@@ -1,4 +1,4 @@
-FROM govim/govim:${GO_VERSION}_${VIM_VERSION}_v1
+FROM govim/govim:${GO_VERSION}_${VIM_FLAVOR}_${VERSION}_v1
 
 ARG USER
 ARG UID
@@ -7,7 +7,8 @@ ARG GID
 ENV PATH=/vbash/bin:/home/$USER/.local/bin:$PATH
 ENV GOPATH=/home/$USER/gopath
 
-RUN groupadd -g $GID $USER && \
+# Create group if it doesn't exist
+RUN sh -c "if ! getent group $GID; then groupadd -g $GID $USER; fi" && \
     adduser --uid $UID --gid $GID --disabled-password --gecos "" $USER
 
 # enable sudo

--- a/Dockerfile.vim
+++ b/Dockerfile.vim
@@ -1,0 +1,14 @@
+ARG GO_VERSION
+ARG VBASHVERSION
+FROM govim/govim:base_${GO_VERSION}_${VBASHVERSION}
+
+ARG VIM_VERSION
+RUN cd /tmp && \
+  git clone https://github.com/vim/vim && \
+  cd vim && \
+  git checkout $VIM_VERSION && \
+  ./configure --prefix=/vim --enable-gui=gtk2 --disable-darwin --disable-selinux --disable-netbeans && \
+  make -j$(nproc --all) install
+
+ENV PATH=/vim/bin:$PATH
+

--- a/_scripts/buildGovimImage.sh
+++ b/_scripts/buildGovimImage.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env vbash
 
-set -eu
+set -euo pipefail
 
 # Usage; either:
 #
 #   buildGovimImage.sh
-#   buildGovimImage.sh VIMVERSION GOVERSION
+#   buildGovimImage.sh VIMFLAVOR VIMVERSION GOVERSION
 #
 
-if [ "$#" -eq 2 ]
+if [ "$#" -eq 3 ]
 then
-	VIM_VERSION="$1"
-	GO_VERSION="$2"
+    VIM_FLAVOR="$1"
+	VIM_VERSION="$2"
+	GO_VERSION="$3"
 else
+    VIM_FLAVOR="${VIM_FLAVOR:-vim}"
 	VIM_VERSION=$(echo $VIM_VERSIONS | tr ',' '\n' | tail -n 1)
 	GO_VERSION=$(echo $GO_VERSIONS | tr ',' '\n' | tail -n 1)
 fi
 
-cat Dockerfile.user | GO_VERSION=$GO_VERSION VIM_VERSION=$VIM_VERSION envsubst '$GO_VERSION,$VIM_VERSION' | docker build -t govim --build-arg USER=$USER --build-arg UID=$UID --build-arg GID=$(id -g $USER) -
+
+cat Dockerfile.user \
+    | GO_VERSION=$GO_VERSION VIM_FLAVOR=$VIM_FLAVOR VERSION=$VIM_VERSION envsubst '$GO_VERSION,$VIM_FLAVOR,$VERSION' \
+    | docker build -t govim --build-arg USER=$USER --build-arg UID=$UID --build-arg GID=$(id -g $USER) -

--- a/_scripts/rebuildDockerImages.sh
+++ b/_scripts/rebuildDockerImages.sh
@@ -5,14 +5,15 @@ set -eu
 
 # Usage; either:
 #
-#   rebuildDockerImsages.sh
-#   rebuildDockerImsages.sh VIMVERSION GOVERSION
+#   rebuildDockerImages.sh
+#   rebuildDockerImages.sh VIMVERSION GOVERSION NEOVIMVERSION
 #
 
-if [ "$#" -eq 2 ]
+if [ "$#" -eq 3 ]
 then
 	VIM_VERSIONS="$1"
 	GO_VERSIONS="$2"
+	NEOVIM_VERSIONS="$3"
 else
 	if [ "${VIM_VERSIONS:-}" == "" ]
 	then
@@ -22,15 +23,36 @@ else
 	then
 		GO_VERSIONS="$GO_VERSION"
 	fi
+	if [ "${NEOVIM_VERSIONS:-}" == "" ]
+	then
+		NEOVIM_VERSIONS="$NEOVIM_VERSION"
+	fi
 fi
 
 vbashVersion="$(go list -m -f={{.Version}} github.com/myitcv/vbash)"
 
+# Build base layer image
+echo running docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=${GO_VERSION}" -t govim/govim:base_${GO_VERSION}_${vbashVersion} -f Dockerfile.base .
+docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=${GO_VERSION}" -t govim/govim:base_${GO_VERSION}_${vbashVersion} -f Dockerfile.base .
+
+
+# Build Vim images
 for i in $(echo "$VIM_VERSIONS" | tr ',' '\n')
 do
 	for j in $(echo "$GO_VERSIONS" | tr ',' '\n')
 	do
-		echo running docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "VIM_VERSION=$i" -t govim/govim:${j}_${i} .
-		docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "VIM_VERSION=$i" -t govim/govim:${j}_${i}_v1 .
+		echo running docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "VIM_VERSION=$i" -t govim/govim:${j}_${i} -f Dockerfile.nvim .
+		docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "VIM_VERSION=$i" -t govim/govim:${j}_vim_${i}_v1 -f Dockerfile.vim .
+	done
+done
+
+
+# Build Neovim images
+for i in $(echo "$NEOVIM_VERSIONS" | tr ',' '\n')
+do
+	for j in $(echo "$GO_VERSIONS" | tr ',' '\n')
+	do
+		echo running docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "VIM_VERSION=$i" -t govim/govim:${j}_${i} -f Dockerfile.nvim .
+		docker build --build-arg "VBASHVERSION=$vbashVersion" --build-arg "GO_VERSION=$j" --build-arg "NEOVIM_VERSION=$i" -t govim/govim:${j}_nvim_${i}_v1 -f Dockerfile.nvim .
 	done
 done


### PR DESCRIPTION
This adds a separate Docker image with Neovim for running the govim tests on CI, as suggested in https://github.com/myitcv/govim/pull/186#issuecomment-488624860.

I decided to split out the `Dockerfile` into a `Dockerfile.vim` and `Dockerfile.nvim` (both building atop a `Dockerfile.base` layer with Go/vbash) rather than build both in the same image; this feels cleaner to me and avoids having image tags like `myitcv/govim:go1.12.4_vim_v8.1.1158_nvim_v0.3.5_v1`, but I don't feel strongly about this approach. It may make sense to move the Docker images into a subdirectory.

I've been able to test this locally using, e.g.  `GO_VERSION=go1.12.4 VIM_VERSION=v8.1.1158 NEOVIM_VERSIONS=v0.3.4,v0.3.5 _scripts/rebuildDockerImages.sh` - it builds the Vim and Neovim images separately.