### PR TITLE
cmd/govim: use test_setmouse in test for default go-to-def mappings

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -57,6 +57,7 @@ func TestScripts(t *testing.T) {
 			Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
 				"sleep": testdriver.Sleep,
 			},
+			Condition: testdriver.Condition,
 			Setup: func(e *testscript.Env) error {
 				// We set a special TMPDIR so the file watcher ignores it
 				tmp := filepath.Join(e.WorkDir, "_tmp")

--- a/cmd/govim/testdata/mapping_defaults_go_to_def.txt
+++ b/cmd/govim/testdata/mapping_defaults_go_to_def.txt
@@ -39,8 +39,27 @@ vim ex 'call feedkeys(\"\\<C-t>\", \"x\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[5,15]\E$'
 
-# <C-LeftMouse> and <C-RightMouse> - can't be handled yet
-# g<LeftMouse> and g<RightMouse> - can't be handled yet
+# Vim only, and at least v8.1.1262
+[!vim] skip 'Need Vim for test_setmouse'
+[!vim:v8.1.1262] skip 'Need at least v8.1.1262 for test_setmouse'
+
+# <C-LeftMouse> and <C-RightMouse>
+vim ex 'call test_setmouse(5,15)'
+vim ex 'call feedkeys(\"\\<C-LeftMouse>\", \"x\")'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[6,7]\E$'
+vim ex 'call feedkeys(\"\\<C-RightMouse>\", \"x\")'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[5,15]\E$'
+
+# g<LeftMouse> and g<RightMouse>
+vim ex 'call test_setmouse(5,15)'
+vim ex 'call feedkeys(\"g\\<LeftMouse>\", \"x\")'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[6,7]\E$'
+vim ex 'call feedkeys(\"g\\<RightMouse>\", \"x\")'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[5,15]\E$'
 
 -- go.mod --
 module mod.com/p

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -5,5 +5,5 @@ nnoremap <buffer> <silent> <C-]> :GOVIMGoToDef<cr>
 nnoremap <buffer> <silent> <C-LeftMouse> <LeftMouse>:GOVIMGoToDef<cr>
 nnoremap <buffer> <silent> g<LeftMouse> <LeftMouse>:GOVIMGoToDef<cr>
 nnoremap <buffer> <silent> <C-t> :GOVIMGoToPrevDef<cr>
-nnoremap <buffer> <silent> <C-RightMouse> <RightMouse>:GOVIMGoToPrevDef<cr>
-nnoremap <buffer> <silent> g<RightMouse> <RightMouse>:GOVIMGoToPrevDef<cr>
+nnoremap <buffer> <silent> <C-RightMouse> :GOVIMGoToPrevDef<cr>
+nnoremap <buffer> <silent> g<RightMouse> :GOVIMGoToPrevDef<cr>


### PR DESCRIPTION
Following
https://github.com/vim/vim/commit/bb8476be871811e40ddc88c598d9e553aba7fb79
we have the ability to call test_setmouse to simulate mouse position.
This allows us to then add coverage to the default mappings for
GOVIMGoToDef and GOVIMGoToPrevDef.

Fix a bug in the default mappings that became clear with these tests.