### PR TITLE
cmd/govim: fix completion

### DIFF
--- a/cmd/govim/complete.go
+++ b/cmd/govim/complete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
+	"github.com/myitcv/govim/cmd/govim/types"
 )
 
 func (v *vimstate) complete(args ...json.RawMessage) (interface{}, error) {
@@ -30,8 +31,21 @@ func (v *vimstate) complete(args ...json.RawMessage) (interface{}, error) {
 			return nil, fmt.Errorf("called to gopls.Completion failed: %v", err)
 		}
 
+		// Slightly bizarre (and I'm not entirely sure how it would/should work)
+		// but each returned completion item can specify its own completion start
+		// point. Vim does not appear to support something like this, so for now
+		// let's just see how far we can get by taking the range of the first item
+
+		start := pos.Col()
+		if len(res.Items) > 0 {
+			pos, err := types.PointFromPosition(b, res.Items[0].TextEdit.Range.Start)
+			if err != nil {
+				return nil, fmt.Errorf("failed to derive completion start: %v", err)
+			}
+			start = pos.Col() - 1 // see help complete-functions
+		}
 		v.lastCompleteResults = res
-		return pos.Col(), nil
+		return start, nil
 	} else {
 		var matches []completionResult
 		for _, i := range v.lastCompleteResults.Items {

--- a/cmd/govim/testdata/complete.txt
+++ b/cmd/govim/testdata/complete.txt
@@ -2,8 +2,8 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
-vim ex 'call cursor(11,16)'
-vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
+vim ex 'call cursor(11,17)'
+vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'
 cmp main.go main.go.golden
 
@@ -21,7 +21,7 @@ const (
 )
 
 func main() {
-	fmt.Println()
+	fmt.Println(Con)
 }
 -- main.go.golden --
 package main


### PR DESCRIPTION
https://go-review.googlesource.com/c/tools/+/176958 changed the
TextEdits returned from gopls to not be the trimmed version of the
label. This meant that we were effectively appending the entire
completion text after the prefix.

This wasn't caught in the completion tests because there we were
attempting a "naked" completion with no prefix.

Fix by fixing the test (which confirmed the bug) then fixing the results
returned from gopls.

Seemingly, a list of completion items from gopls can specify a start
position per item. This does not appear to be supported by Vim (see
:help complete-functions)