### PR TITLE
cmd/govim: mark some functions as internal

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -3,6 +3,10 @@
 package config
 
 const (
+	internalFunctionPrefix = "_internal_"
+)
+
+const (
 	GlobalPrefix = "g:govim_"
 
 	// GlobalFormatOnSave is a string value variable that configures which tool
@@ -52,13 +56,13 @@ const (
 type Function string
 
 const (
-	// FunctionBalloonExpr is not intended to be called by the user. Instead it
-	// is automatically set as the value of balloonexpr by govim.
-	FunctionBalloonExpr Function = "BalloonExpr"
+	// FunctionBalloonExpr is an internal function used by govim for balloonexpr
+	// in Vim
+	FunctionBalloonExpr Function = internalFunctionPrefix + "BalloonExpr"
 
-	// FunctionComplete is not intended to be called by the user. Instead it is
-	// automatically set as the value of omnifunc by govim.
-	FunctionComplete Function = "Complete"
+	// FunctionComplete is an internal function used by govim as for omnifunc in
+	// Vim
+	FunctionComplete Function = internalFunctionPrefix + "Complete"
 
 	// FunctionHover returns the same text that would be returned by a
 	// mouse-based hover, but instead uses the cursor position for the

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -1,5 +1,5 @@
-setlocal balloonexpr=GOVIMBalloonExpr()
-setlocal omnifunc=GOVIMComplete
+setlocal balloonexpr=GOVIM_internal_BalloonExpr()
+setlocal omnifunc=GOVIM_internal_Complete
 nnoremap <buffer> <silent> gd :GOVIMGoToDef<cr>
 nnoremap <buffer> <silent> <C-]> :GOVIMGoToDef<cr>
 nnoremap <buffer> <silent> <C-LeftMouse> <LeftMouse>:GOVIMGoToDef<cr>


### PR DESCRIPTION
Helps the user distinguish between end-user functions and internal
functions that are only exposed for use by govim.

These internal functions could well at a later date be flipped to be
further obscured as closures of the plugin/govim.vim script (and hence
not even named).