### PR TITLE
ci: make GH_USER and GH_TOKEN optional

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -37,8 +37,11 @@ Environment is:
   VIM_COMMAND=$VIM_COMMAND
 EOD
 
-echo -e "machine github.com\n  login $GH_USER\n  password $GH_TOKEN" >> ~/.netrc
-echo -e "machine githubusercontent.com\n  login $GH_USER\n  password $GH_TOKEN" >> ~/.netrc
+if [ "${GH_USER:-}" != "" ] && [ "${GH_TOKEN:-}" != "" ]
+then
+	echo -e "machine github.com\n  login $GH_USER\n  password $GH_TOKEN" >> ~/.netrc
+	echo -e "machine githubusercontent.com\n  login $GH_USER\n  password $GH_TOKEN" >> ~/.netrc
+fi
 
 go version
 vim --version


### PR DESCRIPTION
For ad hoc testing within a docker container, these are not essential.
Particularly of GOPROXY is now set.