### PR TITLE
cmd/govim: change default of GOVIM_DISABLE_INCREMENTALSYNC to true

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -302,8 +302,8 @@ func (g *govimplugin) doIncrementalSync() bool {
 	if semver.Compare(g.Version(), testsetup.MinVimIncrementalSyncExperiment) < 0 {
 		return false
 	}
-	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "true" {
-		return false
+	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "false" {
+		return true
 	}
-	return true
+	return false
 }


### PR DESCRIPTION
Means that by default incremental updates will be off.