### PR TITLE
cmd/govim: fix and re-enable deltas; apply format updates in batches

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -302,8 +302,8 @@ func (g *govimplugin) doIncrementalSync() bool {
 	if semver.Compare(g.Version(), testsetup.MinVimIncrementalSyncExperiment) < 0 {
 		return false
 	}
-	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "false" {
-		return true
+	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "true" {
+		return false
 	}
-	return false
+	return true
 }

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -340,17 +340,23 @@ endfunction
 
 function GOVIM_internal_EnrichDelta(bufnr, start, end, added, changes)
   for l:change in a:changes
-    if l:change.added < 0
-      let l:change.type = "deleted"
-    else
-      if l:change.lnum != l:change.end
-        let l:change.type = "changed"
-        let l:change.lines = getbufline(a:bufnr, l:change.lnum, l:change.end-1+l:change.added)
-      elseif l:change.added > 0
-        let l:change.type = "inserted"
-        let l:change.lines = getbufline(a:bufnr, l:change.lnum, l:change.lnum+l:change.added-1)
-      endif
-    endif
+    let l:change.lines = getbufline(a:bufnr, l:change.lnum, l:change.end-1+l:change.added)
   endfor
   call GOVIM_internal_BufChanged(a:bufnr, a:start, a:end, a:added, a:changes)
+endfunction
+
+function s:applyVimEdits(batch)
+  for e in a:batch.Edits
+    try | silent undojoin | catch | endtry
+    if e.Type == "delete"
+      call deletebufline(a:batch.BufNr, e.Start, e.End)
+    elseif e.Type == "append"
+      call appendbufline(a:batch.BufNr, e.Start, e.Lines)
+    else
+      throw "Unknown edit type ".e.Type
+    endif
+  endfor
+  if a:batch.Flush
+    call listener_flush(a:batch.BufNr)
+  endif
 endfunction


### PR DESCRIPTION
This way, we always make changes to buffers in Vim/VimScript. This
avoids the scenario described in
https://github.com/vim/vim/issues/4438#issuecomment-496448888.