### PR TITLE
cmd/govim: do not show LogMessage arguments

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -24,10 +24,6 @@ func (g *govimplugin) ShowMessageRequest(context.Context, *protocol.ShowMessageR
 }
 func (g *govimplugin) LogMessage(ctxt context.Context, params *protocol.LogMessageParams) error {
 	g.logGoplsClientf("LogMessage callback: %v", pretty.Sprint(params))
-	switch params.Type {
-	case protocol.Error:
-		g.ChannelExf("echohl ErrorMsg | echom %q | echohl None", params.Message)
-	}
 	return nil
 }
 func (g *govimplugin) Telemetry(context.Context, interface{}) error {


### PR DESCRIPTION
The window/logMessage method is exactly that; a means for the server to
log a message with the client. It is distinct from window/showMessage
(not yet used in gopls).

We were, therefore, incorrectly showing messages that were being logged
by the LSP server.