### PR TITLE
cmd/govim: accept logfile template via GOVIM_LOGFILE_TMPL

### DIFF
--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -25,6 +25,8 @@ const (
 
 	EnvDisableIncrementalSync = "GOVIM_DISABLE_INCREMENTALSYNC"
 	MinVimIncrementalSync     = "v8.1.1419"
+
+	EnvLogfileTmpl = "GOVIM_LOGFILE_TMPL"
 )
 
 var (


### PR DESCRIPTION
This means that doing quick repros of problems etc doesn't result in
lots of separate vim channel/govim log files for different Vim sessions.
This way, be setting GOVIM_LOGFILE_TMPL=%v, you then have a stable file
that is logged to, and hence can tail etc without needing to change the
file you are tailing.