### PR TITLE
govim: remove viewport subscription code

### DIFF
--- a/cmd/govim/format.go
+++ b/cmd/govim/format.go
@@ -139,8 +139,6 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 	preEventIgnore := v.ParseString(v.ChannelExpr("&eventignore"))
 	v.ChannelEx("set eventignore=all")
 	defer v.ChannelExf("set eventignore=%v", preEventIgnore)
-	v.ToggleOnViewportChange()
-	defer v.ToggleOnViewportChange()
 	vimEdits := editBatch{
 		Flush: v.doIncrementalSync(),
 		BufNr: b.Num,


### PR DESCRIPTION
Vim is not currently in a position to be able to accurately push
viewport changes to govim. Hence, we might as well drop this code, not
least because it clutters the log messages having the viewport changes
being pushed the whole time. But also because we don't have anything in
govim that relies on knowing when the viewport changes (that is #24).

This should also make adding the Neovim support easier.