### PR TITLE
cmd/govim: fix quickfix implementation

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/myitcv/govim"
+	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/cmd/govim/internal/span"
 )
@@ -70,7 +71,11 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 		v.diagnostics[span.URI(params.URI)] = params.Diagnostics
 		v.diagnosticsChanged = true
 
-		return nil
+		if v.ParseInt(v.ChannelExprf("exists(%q)", config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 &&
+			v.ParseInt(v.ChannelExpr(config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 {
+			return nil
+		}
+		return v.updateQuickfix()
 	})
 	return nil
 }

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -177,7 +177,6 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandGoToDef), g.gotoDef, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandGoToPrevDef), g.gotoPrevDef, govim.NArgsZeroOrOne, govim.CountN(1))
 	g.DefineFunction(string(config.FunctionHover), []string{}, g.hover)
-	g.DefineAutoCommand("", govim.Events{govim.EventCursorHold, govim.EventCursorHoldI}, govim.Patterns{"*.go"}, false, g.autoUpdateQuickfix)
 	g.DefineAutoCommand("", govim.Events{govim.EventBufDelete}, govim.Patterns{"*.go"}, false, g.deleteCurrentBuffer, "eval(expand('<abuf>'))")
 	g.DefineCommand(string(config.CommandGoFmt), g.gofmtCurrentBufferRange, govim.RangeFile)
 	g.DefineCommand(string(config.CommandGoImports), g.goimportsCurrentBufferRange, govim.RangeFile)

--- a/cmd/govim/quickfix.go
+++ b/cmd/govim/quickfix.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/myitcv/govim"
-	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/span"
 	"github.com/myitcv/govim/cmd/govim/types"
 )
@@ -20,15 +19,6 @@ type quickfixEntry struct {
 }
 
 func (v *vimstate) quickfixDiagnostics(flags govim.CommandFlags, args ...string) error {
-	return v.updateQuickfix()
-}
-
-func (v *vimstate) autoUpdateQuickfix(args ...json.RawMessage) error {
-	// TODO this double round-trip is not very efficient
-	if v.ParseInt(v.ChannelExprf("exists(%q)", config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 &&
-		v.ParseInt(v.ChannelExpr(config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 {
-		return nil
-	}
 	return v.updateQuickfix()
 }
 

--- a/cmd/govim/testdata/quickfix.txt
+++ b/cmd/govim/testdata/quickfix.txt
@@ -1,0 +1,21 @@
+# Test that the quickfix window gets populated with error messages from gopls
+
+vim ex 'e main.go'
+errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim ex 'copen'
+vim ex 'w errors'
+cmp errors errors.golden
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("This is a test %v\n")
+}
+-- errors.golden --
+main.go|6 col 2| Printf format %v reads arg #1, but call has 0 args


### PR DESCRIPTION
The current implementation of populating the quickfix window relied on the
CursorHold/CursorHoldI event firing _after_ the diagnostics for a file
had been delivered. However, this is obviously completely wrong; there
is nothing that guarantees this condition will always hold.

Instead, simply use the event of new diagnostics being delivered from
gopls to update the quickfix window.

Fixes #255