### PR TITLE
cmd/govim: add GOVIM_TESTSCRIPT_STDERR to quickly turn on stderr output

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kr/pty"
 	"github.com/myitcv/govim/testdriver"
+	"github.com/myitcv/govim/testsetup"
 	"github.com/rogpeppe/go-internal/testscript"
 	"gopkg.in/retry.v1"
 )
@@ -88,10 +89,13 @@ func TestScripts(t *testing.T) {
 					t.Fatalf("failed to create new driver: %v", err)
 				}
 				errLog := new(lockingBuffer)
-				td.Log = io.MultiWriter(
+				outputs := []io.Writer{
 					errLog,
-					// os.Stderr,
-				)
+				}
+				if os.Getenv(testsetup.EnvTestscriptStderr) == "true" {
+					outputs = append(outputs, os.Stderr)
+				}
+				td.Log = io.MultiWriter(outputs...)
 				e.Values[keyErrLog] = errLog
 				if *fLogGovim {
 					tf, err := ioutil.TempFile("", "govim_test_script_govim_log*")

--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -26,7 +26,8 @@ const (
 	EnvDisableIncrementalSync = "GOVIM_DISABLE_INCREMENTALSYNC"
 	MinVimIncrementalSync     = "v8.1.1419"
 
-	EnvLogfileTmpl = "GOVIM_LOGFILE_TMPL"
+	EnvLogfileTmpl      = "GOVIM_LOGFILE_TMPL"
+	EnvTestscriptStderr = "GOVIM_TESTSCRIPT_STDERR"
 )
 
 var (


### PR DESCRIPTION
This makes it much easier to turn out govim logging to stderr when
debugging issues.