### PR TITLE
cmd/govim: switch to using config functions

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -1,0 +1,49 @@
+let s:config = {}
+let s:func=0
+
+function! govim#config#Set(key,value)
+  if a:key == "_internal_Func"
+    let s:func=a:value
+  else
+    if !has_key(s:validators, a:key)
+      throw "Tried to set config for invalid key ".a:key
+    endif
+    let Func = s:validators[a:key]
+    if !call(Func, [a:value])
+      throw "Tried to set invalid value for key ".a:key.": ".a:value
+    endif
+    let s:config[a:key] = a:value
+  endif
+  call s:pushConfig()
+endfunction
+
+function! govim#config#Unset(key)
+  let s:config = remove(s:config, a:key)
+  call s:pushConfig()
+endfunction
+
+function! govim#config#Get()
+  return copy(s:config)
+endfunction
+
+function! s:pushConfig()
+  if s:func != 0
+    let Func = s:func
+    call call(Func, [s:config])
+  endif
+endfunction
+
+function! s:validFormatOnSave(v)
+  return index(["", "gofmt", "goimports"], a:v) >= 0
+endfunction
+
+function! s:validQuickfixAutoDiagnosticsDisable(v)
+  return type(a:v) == 0
+endfunction
+
+let s:validators = {
+      \ "FormatOnSave": function("s:validFormatOnSave"),
+      \ "QuickfixAutoDiagnosticsDisable": function("s:validQuickfixAutoDiagnosticsDisable"),
+      \ }
+
+call govim#config#Set("FormatOnSave", "goimports")

--- a/channel_cmds.go
+++ b/channel_cmds.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"gopkg.in/tomb.v2"
 )
 
 func (g *govimImpl) handleChannelError(ch unscheduledCallback, err error, format string, args ...interface{}) error {
@@ -124,6 +126,9 @@ func (g *govimImpl) DoProto(f func() error) (err error) {
 				}
 				err = r
 			case error:
+				if r == tomb.ErrDying {
+					panic(ErrShuttingDown)
+				}
 				if r == ErrShuttingDown {
 					panic(r)
 				}

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -6,23 +6,21 @@ const (
 	internalFunctionPrefix = "_internal_"
 )
 
-const (
-	GlobalPrefix = "g:govim_"
+type Config struct {
+	// FormatOnSave is a string value that configures which tool to use for
+	// formatting on save. Options are given by constants of type FormatOnSave.
+	// Default: FormatOnSaveGoImports.
+	FormatOnSave FormatOnSave
 
-	// GlobalFormatOnSave is a string value variable that configures which tool
-	// to use for formatting on save. Options are given by constants of type
-	// FormatOnSave. Default: FormatOnSaveGoImports.
-	GlobalFormatOnSave = GlobalPrefix + "format_on_save"
-
-	// GlobalQuickfixAutoDiagnosticsDisable is a boolean (0 or 1 in VimScript)
-	// variable that controls whether auto-population of the quickfix window
-	// with gopls diagnostics is disabled or not. When not disabled, govim waits
-	// for updatetime (help updatetime) before populating the quickfix window
-	// with the current gopls diagnostics. When disabled, the
+	// QuickfixAutoDiagnosticsDisable is a boolean (0 or 1 in VimScript) that
+	// controls whether auto-population of the quickfix window with gopls
+	// diagnostics is disabled or not. When not disabled, govim waits for
+	// updatetime (help updatetime) before populating the quickfix window with
+	// the current gopls diagnostics. When disabled, the
 	// CommandQuickfixDiagnostics command can be used to manually trigger the
 	// population. Default: false (0)
-	GlobalQuickfixAutoDiagnosticsDisable = GlobalPrefix + "quickfix_auto_diagnotics_disable"
-)
+	QuickfixAutoDiagnosticsDisable bool
+}
 
 type Command string
 
@@ -80,6 +78,10 @@ const (
 	// FunctionEnrichDelta is an internal function used by govim for enriching
 	// listener_add based callbacks before calling FunctionBufChanged
 	FunctionEnrichDelta = internalFunctionPrefix + "EnrichDelta"
+
+	// FunctionSetConfig is an internal function used by govim for pushing config
+	// changes from Vim to govim.
+	FunctionSetConfig = internalFunctionPrefix + "SetConfig"
 )
 
 // FormatOnSave typed constants define the set of valid values that

--- a/cmd/govim/format.go
+++ b/cmd/govim/format.go
@@ -25,14 +25,14 @@ func (v *vimstate) formatCurrentBuffer(args ...json.RawMessage) (err error) {
 	if !ok {
 		return fmt.Errorf("failed to resolve buffer %v", currBufNr)
 	}
-	tool := config.FormatOnSave(v.ParseString(v.ChannelExpr(config.GlobalFormatOnSave)))
+	tool := v.config.FormatOnSave
 	// TODO we should move this validation elsewhere...
 	switch tool {
 	case config.FormatOnSaveNone:
 		return nil
 	case config.FormatOnSaveGoFmt, config.FormatOnSaveGoImports:
 	default:
-		return fmt.Errorf("unknown format tool specified for %v: %v", config.GlobalFormatOnSave, tool)
+		return fmt.Errorf("unknown format tool specified: %v", tool)
 	}
 	return v.formatBufferRange(b, tool, govim.CommandFlags{})
 }
@@ -114,7 +114,7 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 			return fmt.Errorf("don't know how to handle %v actions", len(actions))
 		}
 	default:
-		return fmt.Errorf("unknown format mode specified for %v: %v", config.GlobalFormatOnSave, mode)
+		return fmt.Errorf("unknown format mode specified: %v", mode)
 	}
 
 	// see :help wundo. The use of wundo! is significant. It first deletes

--- a/cmd/govim/functions.go
+++ b/cmd/govim/functions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/myitcv/govim"
+	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/cmd/govim/internal/span"
 	"github.com/myitcv/govim/cmd/govim/types"
@@ -36,6 +37,21 @@ type vimstate struct {
 	// returns the matching words. This is by definition stateful. Hence we persist that
 	// state here
 	lastCompleteResults *protocol.CompletionList
+
+	config config.Config
+}
+
+func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
+	var c struct {
+		FormatOnSave                   config.FormatOnSave
+		QuickfixAutoDiagnosticsDisable int
+	}
+	v.Parse(args[0], &c)
+	v.config = config.Config{
+		FormatOnSave:                   c.FormatOnSave,
+		QuickfixAutoDiagnosticsDisable: c.QuickfixAutoDiagnosticsDisable != 0,
+	}
+	return nil, nil
 }
 
 func (v *vimstate) hello(args ...json.RawMessage) (interface{}, error) {

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/myitcv/govim"
-	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/cmd/govim/internal/span"
 )
@@ -71,8 +70,7 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 		v.diagnostics[span.URI(params.URI)] = params.Diagnostics
 		v.diagnosticsChanged = true
 
-		if v.ParseInt(v.ChannelExprf("exists(%q)", config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 &&
-			v.ParseInt(v.ChannelExpr(config.GlobalQuickfixAutoDiagnosticsDisable)) != 0 {
+		if v.config.QuickfixAutoDiagnosticsDisable {
 			return nil
 		}
 		return v.updateQuickfix()

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -28,6 +28,10 @@ import (
 	"github.com/rogpeppe/go-internal/semver"
 )
 
+const (
+	PluginPrefix = "GOVIM"
+)
+
 var (
 	fTail = flag.Bool("tail", false, "whether to also log output to stdout")
 
@@ -145,7 +149,7 @@ type govimplugin struct {
 }
 
 func newplugin(goplspath string) *govimplugin {
-	d := plugin.NewDriver("GOVIM")
+	d := plugin.NewDriver(PluginPrefix)
 	res := &govimplugin{
 		goplspath: goplspath,
 		Driver:    d,
@@ -182,6 +186,8 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandGoImports), g.goimportsCurrentBufferRange, govim.RangeFile)
 	g.DefineCommand(string(config.CommandQuickfixDiagnostics), g.quickfixDiagnostics)
 	g.DefineFunction(string(config.FunctionBufChanged), []string{"bufnr", "start", "end", "added", "changes"}, g.bufChanged)
+	g.DefineFunction(string(config.FunctionSetConfig), []string{"config"}, g.setConfig)
+	g.ChannelExf(`call govim#config#Set("_internal_Func", function("%v%v"))`, PluginPrefix, config.FunctionSetConfig)
 
 	g.isGui = g.ParseInt(g.ChannelExpr(`has("gui_running")`)) == 1
 

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -105,7 +105,9 @@ func TestScripts(t *testing.T) {
 					td.Log = tf
 					t.Logf("logging %v to %v\n", filepath.Base(e.WorkDir), tf.Name())
 				}
-				td.Run()
+				if err := td.Run(); err != nil {
+					t.Fatalf("failed to run TestDriver: %v", err)
+				}
 				waitLock.Lock()
 				waitList = append(waitList, td.Wait)
 				waitLock.Unlock()

--- a/cmd/govim/testdata/format_on_save_none.txt
+++ b/cmd/govim/testdata/format_on_save_none.txt
@@ -1,7 +1,7 @@
-# Test that g:govim_format_on_save="" works
+# Test that govim#config#Set("FormatOnSave", "") works
 
 cp file.go.orig file.go
-vim ex 'let g:govim_format_on_save=\"\"'
+vim call 'govim#config#Set' '["FormatOnSave", ""]'
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.orig

--- a/cmd/govim/testdata/gofmt.txt
+++ b/cmd/govim/testdata/gofmt.txt
@@ -1,4 +1,4 @@
-# Test that g:govim_format_on_save="gofmt" and GOVIMGoFmt work
+# Test that govim#config#Set("FormatOnSave", "gofmt") and GOVIMGoFmt work
 
 # We need to skip this entire test for now because of flakey Formatting method
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31759'
@@ -21,7 +21,7 @@ cmp file.go file.go.gofmt
 
 # Format on save
 cp file.go.orig file.go
-vim ex 'let g:govim_format_on_save=\"gofmt\"'
+vim call govim#config#Set '["FormatOnSave", "gofmt"]'
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.gofmt

--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -1,12 +1,12 @@
-# Test that g:govim_format_on_save="goimports" works
+# Test that govim#config#Set("FormatOnSave", "goimports") and GOVIMGoImports work
 
 # Ensure the default is goimports
-vim expr 'g:govim_format_on_save'
+vim expr 'govim#config#Get().FormatOnSave'
 stdout '^"goimports"$'
 
 # goimports
 cp file.go.orig file.go
-vim ex 'let g:govim_format_on_save=\"goimports\"'
+vim call 'govim#config#Set' '["FormatOnSave", "goimports"]'
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.goimports

--- a/event_queue.go
+++ b/event_queue.go
@@ -67,7 +67,7 @@ func (e eventQueueInst) handleUserQValueAndError(ch scheduledCallback, err error
 	case e.flushEvents <- struct{}{}:
 		select {
 		case <-e.govimImpl.tomb.Dying():
-			return nil, tomb.ErrDying
+			panic(tomb.ErrDying)
 		case resp := <-ch:
 			if resp.errString != "" {
 				args = append(args, resp.errString)

--- a/govim_test.go
+++ b/govim_test.go
@@ -62,7 +62,9 @@ func TestScripts(t *testing.T) {
 					td.Log = tf
 					t.Logf("logging %v to %v\n", filepath.Base(e.WorkDir), tf.Name())
 				}
-				td.Run()
+				if err := td.Run(); err != nil {
+					t.Fatalf("failed to run TestDriver: %v", err)
+				}
 				waitLock.Lock()
 				waitList = append(waitList, td.Wait)
 				waitLock.Unlock()

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -82,7 +82,7 @@ function s:callbackAutoCommand(name, exprs)
 endfunction
 
 function s:doShutdown()
-  if s:govim_status != "initcomplete"
+  if s:govim_status != "loaded" && s:govim_status != "initcomplete"
     " TODO anything to do here other than return?
     return
   endif


### PR DESCRIPTION
This moves us from the approach of delacring global variables in one's
.vimrc:

let g:govim_quickfix_auto_diagnotics_disable=1

to calling a config function:

call govim#config#Set("quickfix_auto_diagnotics_disable", 1)

The benefits here being:

* better validation of config setting; this function can error if you try to set
  an invalid key/value
* consistent approach to setting config at startup (.vimrc) or runtime
* more efficient config processing by govim

As part of these changes we also make our load, init and shutdown events
from a Govim instance for explicit, and therefore their handling in
testdriver more robust.

Closes #264