### PR TITLE
cmd/govim: re-enable incremental updates by default

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -322,8 +322,8 @@ func (g *govimplugin) doIncrementalSync() bool {
 	if semver.Compare(g.Version(), testsetup.MinVimIncrementalSync) < 0 {
 		return false
 	}
-	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "false" {
-		return true
+	if os.Getenv(testsetup.EnvDisableIncrementalSync) == "true" {
+		return false
 	}
-	return false
+	return true
 }

--- a/cmd/govim/testdata/complete.txt
+++ b/cmd/govim/testdata/complete.txt
@@ -2,6 +2,7 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
+errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'


### PR DESCRIPTION
Noting however https://github.com/myitcv/govim/issues/266 which is a
known issue. Re-enabling on the basis it's probably better to get more
exposure for this feature in the short term, particularly when there is
a workaround for people who use auto-pairs.