### PR TITLE
testdriver: make errlogmatch more useful

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -16,19 +15,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
-
-	"regexp"
 
 	"github.com/kr/pty"
 	"github.com/myitcv/govim/testdriver"
 	"github.com/myitcv/govim/testsetup"
 	"github.com/rogpeppe/go-internal/testscript"
-	"gopkg.in/retry.v1"
-)
-
-const (
-	keyErrLog = "errLog"
 )
 
 var (
@@ -65,8 +56,8 @@ func TestScripts(t *testing.T) {
 		testscript.Run(t, testscript.Params{
 			Dir: "testdata",
 			Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-				"sleep":      testdriver.Sleep,
-				"errlogwait": errLogWait,
+				"sleep":       testdriver.Sleep,
+				"errlogmatch": testdriver.ErrLogMatch,
 			},
 			Condition: testdriver.Condition,
 			Setup: func(e *testscript.Env) error {
@@ -88,7 +79,7 @@ func TestScripts(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to create new driver: %v", err)
 				}
-				errLog := new(lockingBuffer)
+				errLog := new(testdriver.LockingBuffer)
 				outputs := []io.Writer{
 					errLog,
 				}
@@ -96,7 +87,7 @@ func TestScripts(t *testing.T) {
 					outputs = append(outputs, os.Stderr)
 				}
 				td.Log = io.MultiWriter(outputs...)
-				e.Values[keyErrLog] = errLog
+				e.Values[testdriver.KeyErrLog] = errLog
 				if *fLogGovim {
 					tf, err := ioutil.TempFile("", "govim_test_script_govim_log*")
 					if err != nil {
@@ -192,63 +183,4 @@ func execvim() int {
 		return 1
 	}
 	return 0
-}
-
-type lockingBuffer struct {
-	lock sync.Mutex
-	und  bytes.Buffer
-}
-
-func (l *lockingBuffer) Write(p []byte) (n int, err error) {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	return l.und.Write(p)
-}
-
-func (l *lockingBuffer) Bytes() []byte {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	return l.und.Bytes()
-}
-
-func errLogWait(ts *testscript.TestScript, neg bool, args []string) {
-	if neg {
-		ts.Fatalf("errlogwait does not support negation")
-	}
-	errLogV := ts.Value(keyErrLog)
-	if errLogV == nil {
-		ts.Fatalf("errlogwait failed to find errLog")
-	}
-	errLog, ok := errLogV.(*lockingBuffer)
-	if !ok {
-		ts.Fatalf("errlogwait errLog was not the right type")
-	}
-
-	if len(args) != 1 {
-		ts.Fatalf("errlogwait expects a single argument, the regexp to search for")
-	}
-
-	reg, err := regexp.Compile(args[0])
-	if err != nil {
-		ts.Fatalf("errlogwait failed to regexp.Compile %q: %v", args[0], err)
-	}
-
-	strategy := retry.LimitTime(30*time.Second,
-		retry.Exponential{
-			Initial: 10 * time.Millisecond,
-			Factor:  1.5,
-		},
-	)
-
-	found := false
-	for a := retry.Start(strategy, nil); a.Next(); {
-		if reg.Find(errLog.Bytes()) != nil {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		ts.Fatalf("errlogwait failed to find %q; timed out", args[0])
-	}
 }

--- a/cmd/govim/testdata/complete.txt
+++ b/cmd/govim/testdata/complete.txt
@@ -2,7 +2,7 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
-errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'

--- a/cmd/govim/testdata/complete_watched.txt
+++ b/cmd/govim/testdata/complete_watched.txt
@@ -5,9 +5,9 @@
 # handled.
 
 vim ex 'e main.go'
-errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 cp const.go.orig const.go
-errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
 vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'

--- a/cmd/govim/testdata/go_to_def_useopen.txt
+++ b/cmd/govim/testdata/go_to_def_useopen.txt
@@ -10,7 +10,7 @@ vim ex 'e '$WORK/q/q.go
 vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim ex 'split '$WORK/p.go
-errlogwait '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument:\s+protocol.TextDocumentItem{URI:"file://'$WORK/p.go
+errlogmatch -wait 30s '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument:\s+protocol.TextDocumentItem{URI:"file://'$WORK/p.go
 vim ex 'call cursor(5,17)'
 vim ex 'GOVIMGoToDef'
 vim expr 'bufname(\"\")'

--- a/cmd/govim/testdata/quickfix.txt
+++ b/cmd/govim/testdata/quickfix.txt
@@ -1,7 +1,7 @@
 # Test that the quickfix window gets populated with error messages from gopls
 
 vim ex 'e main.go'
-errlogwait 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden

--- a/testdata/bad_function.txt
+++ b/testdata/bad_function.txt
@@ -1,0 +1,10 @@
+# Test the handling of functions that return errors
+
+# call a bad function
+! errlogmatch 'recvJSONMsg:.*got error whilst handling Bad'
+vim -bang expr 'Bad()'
+! stdout .+
+stderr '^\Qfailed to expr(Bad()) in Vim: Caught ''got error whilst handling Bad: this is a bad function''\E'
+errlogmatch 'recvJSONMsg:.*got error whilst handling Bad'
+! errlogmatch 'recvJSONMsg:.*got error whilst handling Bad'
+errlogmatch -start 'recvJSONMsg:.*got error whilst handling Bad'

--- a/testdata/function.txt
+++ b/testdata/function.txt
@@ -20,11 +20,6 @@ cmp stdout gophers.golden
 vim call Func1
 cmp stdout test.func2.golden
 
-# call a bad function
-vim -bang expr 'Bad()'
-! stdout .+
-stderr '^\Qfailed to expr(Bad()) in Vim: Caught ''got error whilst handling Bad: this is a bad function''\E'
-
 -- test.golden --
 "World"
 -- test.func2.golden --


### PR DESCRIPTION
Also add goplslogcount in order to easily make assertions against the
number of errors (for example) in a test run.