### PR TITLE
cmd/govim: better model for handling syntax errors

### DIFF
--- a/cmd/govim/format.go
+++ b/cmd/govim/format.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kr/pretty"
 	"github.com/myitcv/govim"
 	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
@@ -83,7 +82,8 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 			}
 			edits, err = v.server.RangeFormatting(context.Background(), params)
 			if err != nil {
-				return fmt.Errorf("failed to call gopls.RangeFormatting: %v\nParams were: %v", err, pretty.Sprint(params))
+				v.Logf("gopls.RangeFormatting returned an error; nothing to do")
+				return nil
 			}
 		} else {
 			params := &protocol.DocumentFormattingParams{
@@ -91,7 +91,8 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 			}
 			edits, err = v.server.Formatting(context.Background(), params)
 			if err != nil {
-				return fmt.Errorf("failed to call gopls.Formatting: %v\nParams were: %v", err, pretty.Sprint(params))
+				v.Logf("gopls.Formatting returned an error; nothing to do")
+				return nil
 			}
 		}
 	case config.FormatOnSaveGoImports:
@@ -103,7 +104,8 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 		}
 		actions, err := v.server.CodeAction(context.Background(), params)
 		if err != nil {
-			return fmt.Errorf("failed to call gopls.CodeAction: %v\nParams were: %v", err, pretty.Sprint(params))
+			v.Logf("gopls.CodeAction returned an error; nothing to do")
+			return nil
 		}
 		switch len(actions) {
 		case 0:

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -204,6 +204,7 @@ func goplsLogCount(ts *testscript.TestScript, neg bool, args []string) {
 	}
 
 	fs := flag.NewFlagSet("goplslogcount", flag.ContinueOnError)
+	fStart := fs.Bool("start", false, "search from the start of the error log")
 	fLevel := fs.String("level", "Error", "the log MessageType to search for")
 	if err := fs.Parse(args); err != nil {
 		ts.Fatalf("goplslogcount: failed to parse args %v: %v", args, err)
@@ -229,8 +230,14 @@ func goplsLogCount(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Fatalf("goplslogcount failed to regexp.Compile %q: %v", logErr, err)
 	}
 
-	all, _ := errLog.Bytes()
-	matches := reg.FindAll(all, -1)
+	all, sinceLast := errLog.Bytes()
+	var toSearch []byte
+	if *fStart {
+		toSearch = all
+	} else {
+		toSearch = sinceLast
+	}
+	matches := reg.FindAll(toSearch, -1)
 	if got := len(matches); got != want {
 		// we found a match and were expecting it
 		var matchStrings []string

--- a/cmd/govim/testdata/gofmt.txt
+++ b/cmd/govim/testdata/gofmt.txt
@@ -6,6 +6,25 @@ vim ex 'e! file.go'
 vim ex 'GOVIMGoFmt'
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt
+
+# Format on save
+cp file.go.orig file.go
+vim call 'govim#config#Set' '["FormatOnSave", "gofmt"]'
+vim ex 'e! file.go'
+vim ex 'w'
+cmp file.go file.go.gofmt
+
+goplslogcount 0
+
+# Format on save (bad syntax)
+cp file.go.bad file.go
+vim ex 'e! file.go'
+vim ex 'w'
+cmp file.go file.go.bad
+vim expr 'getqflist()'
+stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
+! stderr .+
+
 goplslogcount 0
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
@@ -17,12 +36,6 @@ vim ex '3,5GOVIMGoFmt'
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt
 
-# Format on save
-cp file.go.orig file.go
-vim call govim#config#Set '["FormatOnSave", "gofmt"]'
-vim ex 'e! file.go'
-vim ex 'w'
-cmp file.go file.go.gofmt
 goplslogcount 0
 
 -- go.mod --
@@ -35,6 +48,10 @@ const ( x = 5
 y = os.PathSeparator
  )
 
+-- file.go.bad --
+package blah
+
+blah
 -- file.go.gofmt --
 package blah
 

--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -4,19 +4,31 @@
 vim expr 'govim#config#Get().FormatOnSave'
 stdout '^"goimports"$'
 
-# goimports
-cp file.go.orig file.go
-vim call 'govim#config#Set' '["FormatOnSave", "goimports"]'
-vim ex 'e! file.go'
-vim ex 'w'
-cmp file.go file.go.goimports
-
 # :GOVIMGoImports whole file
 cp file.go.orig file.go
 vim ex 'e! file.go'
 vim ex 'GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp file.go file.go.goimports
+
+# Format on save
+cp file.go.orig file.go
+vim call 'govim#config#Set' '["FormatOnSave", "goimports"]'
+vim ex 'e! file.go'
+vim ex 'w'
+cmp file.go file.go.goimports
+
+goplslogcount 0
+
+# Format on save (bad syntax)
+cp file.go.bad file.go
+vim ex 'e! file.go'
+vim ex 'w'
+cmp file.go file.go.bad
+vim expr 'getqflist()'
+stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
+! stderr .+
+
 goplslogcount 0
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
@@ -27,6 +39,7 @@ vim ex 'e! file.go'
 vim ex '3,5GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp file.go file.go.goimports
+
 goplslogcount 0
 
 -- go.mod --
@@ -39,6 +52,10 @@ const ( x = 5
 y = os.PathSeparator
  )
 
+-- file.go.bad --
+package blah
+
+blah
 -- file.go.goimports --
 package blah
 


### PR DESCRIPTION
Syntax errors in a file mean that a call to any of the gopls methods
that format the code will fail. This is confirmed by those methods
returning errors.

Currently we return that error to Vim, meaning the error is thrown. Not
only that, but, if the format function is called as part of
format-on-save, then the save is aborted.

Per #274, this is not ideal.

Instead, we choose Option 2 in #274 for now:

* allow the save
* do not echo/throw any error
* rely on the user spotting the syntax error in the quickfix window

We might follow this up with a further PR that automatically shows the
quickfix window if there are any errors in it, but not for now.

Fixes #274