### PR TITLE
testdriver: improve errlogmatch

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -12,15 +12,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/kr/pretty"
 	"github.com/kr/pty"
-	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/testdriver"
 	"github.com/myitcv/govim/testsetup"
 	"github.com/rogpeppe/go-internal/testscript"
@@ -60,9 +56,8 @@ func TestScripts(t *testing.T) {
 		testscript.Run(t, testscript.Params{
 			Dir: "testdata",
 			Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-				"sleep":         testdriver.Sleep,
-				"errlogmatch":   testdriver.ErrLogMatch,
-				"goplslogcount": goplsLogCount,
+				"sleep":       testdriver.Sleep,
+				"errlogmatch": testdriver.ErrLogMatch,
 			},
 			Condition: testdriver.Condition,
 			Setup: func(e *testscript.Env) error {
@@ -188,62 +183,4 @@ func execvim() int {
 		return 1
 	}
 	return 0
-}
-
-func goplsLogCount(ts *testscript.TestScript, neg bool, args []string) {
-	if neg {
-		ts.Fatalf("goplsErrCount does not support neg")
-	}
-	errLogV := ts.Value(testdriver.KeyErrLog)
-	if errLogV == nil {
-		ts.Fatalf("errlogmatch failed to find %v value", testdriver.KeyErrLog)
-	}
-	errLog, ok := errLogV.(*testdriver.LockingBuffer)
-	if !ok {
-		ts.Fatalf("errlogmatch %v was not the right type", testdriver.KeyErrLog)
-	}
-
-	fs := flag.NewFlagSet("goplslogcount", flag.ContinueOnError)
-	fStart := fs.Bool("start", false, "search from the start of the error log")
-	fLevel := fs.String("level", "Error", "the log MessageType to search for")
-	if err := fs.Parse(args); err != nil {
-		ts.Fatalf("goplslogcount: failed to parse args %v: %v", args, err)
-	}
-
-	mt := protocol.ParseMessageType(*fLevel)
-	if mt == 0 {
-		ts.Fatalf("failed to parse MessageType from %q", *fLevel)
-	}
-
-	if len(fs.Args()) != 1 {
-		ts.Fatalf("goplslogcount expects a single argument, the expected count of errors")
-	}
-
-	want, err := strconv.Atoi(fs.Args()[0])
-	if err != nil {
-		ts.Fatalf("goplslogcount failed to parse expected count from %q: %v", fs.Args()[0], err)
-	}
-
-	logErr := fmt.Sprintf(`LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*`, int(mt))
-	reg, err := regexp.Compile(logErr)
-	if err != nil {
-		ts.Fatalf("goplslogcount failed to regexp.Compile %q: %v", logErr, err)
-	}
-
-	all, sinceLast := errLog.Bytes()
-	var toSearch []byte
-	if *fStart {
-		toSearch = all
-	} else {
-		toSearch = sinceLast
-	}
-	matches := reg.FindAll(toSearch, -1)
-	if got := len(matches); got != want {
-		// we found a match and were expecting it
-		var matchStrings []string
-		for _, m := range matches {
-			matchStrings = append(matchStrings, string(m))
-		}
-		ts.Fatalf("goplslogcount: expected %v errors, got %v: %v", want, got, pretty.Sprint(matchStrings))
-	}
 }

--- a/cmd/govim/testdata/bad_complete.txt
+++ b/cmd/govim/testdata/bad_complete.txt
@@ -7,7 +7,7 @@
 vim ex 'e main.go'
 vim ex 'call cursor(5,1)'
 vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\", \"x\")'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/command.txt
+++ b/cmd/govim/testdata/command.txt
@@ -7,4 +7,4 @@ vim ex 'GOVIMHello'
 vim expr 'v:statusmsg'
 stdout '^\Q"Hello from command"\E$'
 ! stderr .+
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'

--- a/cmd/govim/testdata/complete.txt
+++ b/cmd/govim/testdata/complete.txt
@@ -7,7 +7,7 @@ vim ex 'call cursor(11,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'
 cmp main.go main.go.golden
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/complete_watched.txt
+++ b/cmd/govim/testdata/complete_watched.txt
@@ -12,7 +12,7 @@ vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'
 cmp main.go main.go.golden
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/format_on_save_none.txt
+++ b/cmd/govim/testdata/format_on_save_none.txt
@@ -5,7 +5,7 @@ vim call 'govim#config#Set' '["FormatOnSave", ""]'
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.orig
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/function.txt
+++ b/cmd/govim/testdata/function.txt
@@ -3,7 +3,7 @@
 vim normal '\"=GOVIMHello()\u000dp'
 vim ex 'w test'
 cmp test test.golden
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- test.golden --
 Hello from function

--- a/cmd/govim/testdata/function_hover.txt
+++ b/cmd/govim/testdata/function_hover.txt
@@ -5,7 +5,7 @@ vim ex 'call cursor(6,6)'
 vim expr 'GOVIMHover()'
 stdout '^\Q"func fmt.Println(a ...interface{}) (n int, err error)"\E$'
 ! stderr .+
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/go_to_def_newtab.txt
+++ b/cmd/govim/testdata/go_to_def_newtab.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["leaf",1001]\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_same_file.txt
+++ b/cmd/govim/testdata/go_to_def_same_file.txt
@@ -12,7 +12,7 @@ vim expr 'bufname(\"\")'
 stdout '^\Q"'$WORK'/p.go"\E$'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[8,7]\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_split.txt
+++ b/cmd/govim/testdata/go_to_def_split.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["col",[["leaf",1000],["leaf",1001]]]\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_useopen.txt
+++ b/cmd/govim/testdata/go_to_def_useopen.txt
@@ -19,7 +19,7 @@ vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_usetab.txt
+++ b/cmd/govim/testdata/go_to_def_usetab.txt
@@ -20,7 +20,7 @@ vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_vsplit.txt
+++ b/cmd/govim/testdata/go_to_def_vsplit.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["row",[["leaf",1000],["leaf",1001]]]\E$'
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/gofmt.txt
+++ b/cmd/govim/testdata/gofmt.txt
@@ -14,7 +14,7 @@ vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.gofmt
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 # Format on save (bad syntax)
 cp file.go.bad file.go
@@ -25,7 +25,7 @@ vim expr 'getqflist()'
 stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
 ! stderr .+
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -36,7 +36,7 @@ vim ex '3,5GOVIMGoFmt'
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -18,7 +18,7 @@ vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.goimports
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 # Format on save (bad syntax)
 cp file.go.bad file.go
@@ -29,7 +29,7 @@ vim expr 'getqflist()'
 stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
 ! stderr .+
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -40,7 +40,7 @@ vim ex '3,5GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp file.go file.go.goimports
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/mapping_defaults_go_to_def.txt
+++ b/cmd/govim/testdata/mapping_defaults_go_to_def.txt
@@ -61,7 +61,7 @@ vim ex 'call feedkeys(\"g\\<RightMouse>\", \"x\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[3,15]\E$'
 
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/quickfix.txt
+++ b/cmd/govim/testdata/quickfix.txt
@@ -5,7 +5,7 @@ errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnostics
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden
-goplslogcount 0
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com


### PR DESCRIPTION
Drop goplslogcount in favour of the more explicit errlogmatch, which has
now gained a -count flag.