### PR TITLE
cmd/govim: de-dupe PublishDiagnostics notifications from gopls

### DIFF
--- a/cmd/govim/functions.go
+++ b/cmd/govim/functions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/myitcv/govim"
 	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
-	"github.com/myitcv/govim/cmd/govim/internal/span"
 	"github.com/myitcv/govim/cmd/govim/types"
 	"github.com/myitcv/govim/internal/plugin"
 )
@@ -23,10 +22,6 @@ type vimstate struct {
 	// watchedFiles is a map of files that we are handling via file watching
 	// events, rather than via open Buffers in Vim
 	watchedFiles map[string]*types.WatchedFile
-
-	// diagnostics gives us the current diagnostics by URI
-	diagnostics        map[span.URI][]protocol.Diagnostic
-	diagnosticsChanged bool
 
 	// jumpStack is akin to the Vim concept of a tagstack
 	jumpStack    []protocol.Location

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/myitcv/govim"
@@ -146,18 +147,22 @@ type govimplugin struct {
 	tomb tomb.Tomb
 
 	modWatcher *modWatcher
+
+	// diagnostics gives us the current diagnostics by URI
+	diagnostics     map[span.URI][]protocol.Diagnostic
+	diagnosticsLock sync.Mutex
 }
 
 func newplugin(goplspath string) *govimplugin {
 	d := plugin.NewDriver(PluginPrefix)
 	res := &govimplugin{
-		goplspath: goplspath,
-		Driver:    d,
+		diagnostics: make(map[span.URI][]protocol.Diagnostic),
+		goplspath:   goplspath,
+		Driver:      d,
 		vimstate: &vimstate{
 			Driver:       d,
 			buffers:      make(map[int]*types.Buffer),
 			watchedFiles: make(map[string]*types.WatchedFile),
-			diagnostics:  make(map[span.URI][]protocol.Diagnostic),
 		},
 	}
 	res.vimstate.govimplugin = res


### PR DESCRIPTION
This helps to throttle the number of changes we try to push through to
the quickfix window.

However, https://github.com/golang/go/issues/32443 remains an issue in
as much as incomplete diagnostics are sent to the client. i.e. we can't
be sure to receive the most recent diagnostics for the file which we are
editing (and in which we know, for example, we are making errors).