### PR TITLE
cmd/govim: prevent diagnostics overwriting references

### DIFF
--- a/cmd/govim/functions.go
+++ b/cmd/govim/functions.go
@@ -76,7 +76,7 @@ func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 	var isBusy int
 	v.Parse(args[0], &isBusy)
 	v.userBusy = isBusy != 0
-	if v.userBusy || v.config.QuickfixAutoDiagnosticsDisable {
+	if v.userBusy || v.config.QuickfixAutoDiagnosticsDisable || !v.quickfixIsDiagnostics {
 		return nil, nil
 	}
 	return nil, v.updateQuickfix()


### PR DESCRIPTION
When a call to GOVIMReferences is made, it effectively puts the quick
fix window in a mode where it shows references, not diagnostics. We were
missing a check at the inflection point of "user is busy" for which mode
we were in, and hence in some situations we would override the list of
references with diagnostics (because errors had been introduced since
the call to GOVIMReferences)