### PR TITLE
deps: x/tools and gopls dd7c7173f160

### DIFF
--- a/cmd/govim/internal/lsp/hover.go
+++ b/cmd/govim/internal/lsp/hover.go
@@ -6,8 +6,6 @@ package lsp
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/source"
 	"github.com/myitcv/govim/cmd/govim/internal/span"
@@ -51,20 +49,4 @@ func (s *Server) hover(ctx context.Context, params *protocol.TextDocumentPositio
 		},
 		Range: &rng,
 	}, nil
-}
-
-func markupContent(decl, doc string, kind protocol.MarkupKind) protocol.MarkupContent {
-	result := protocol.MarkupContent{
-		Kind: kind,
-	}
-	switch kind {
-	case protocol.PlainText:
-		result.Value = decl
-	case protocol.Markdown:
-		result.Value = "```go\n" + decl + "\n```"
-	}
-	if doc != "" {
-		result.Value = fmt.Sprintf("%s\n%s", doc, result.Value)
-	}
-	return result
 }

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/rogpeppe/go-internal v1.3.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
-	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
-	golang.org/x/tools/gopls v0.1.2-0.20190706070813-72ffa07ba3db
+	golang.org/x/tools v0.0.0-20190708171232-dd7c7173f160
+	golang.org/x/tools/gopls v0.1.2-0.20190708171232-dd7c7173f160
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	honnef.co/go/tools v0.0.0-20190614002413-cb51c254f01b

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,10 @@ golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190530171427-2b03ca6e44eb/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db h1:9hRk1xeL9LTT3yX/941DqeBz87XgHAQuj+TbimYJuiw=
-golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
-golang.org/x/tools/gopls v0.1.2-0.20190706070813-72ffa07ba3db h1:jEzcdhR4g/qmRjnefU4bjKYInYeXwZRsQqqcnUrVSxk=
-golang.org/x/tools/gopls v0.1.2-0.20190706070813-72ffa07ba3db/go.mod h1:RYlHDmWjvTa1HuWNyEKa6/zzI2ums47cfsozmM0466w=
+golang.org/x/tools v0.0.0-20190708171232-dd7c7173f160 h1:YARKw3xKIhms99Gyx7Z94QJ1FYt92UTpEbN3EM5mJ/M=
+golang.org/x/tools v0.0.0-20190708171232-dd7c7173f160/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools/gopls v0.1.2-0.20190708171232-dd7c7173f160 h1:nxqcllOuhMIsb60f3IHi3TDpDeaF0sX9Xo4K0ROHJYM=
+golang.org/x/tools/gopls v0.1.2-0.20190708171232-dd7c7173f160/go.mod h1:RYlHDmWjvTa1HuWNyEKa6/zzI2ums47cfsozmM0466w=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=


### PR DESCRIPTION
* internal/lsp: remove the unused function 'markupContent'.
* internal/lsp: fix test failure introduced in CL 185058