### PR TITLE
cmd/govim: fix bug for large batches

### DIFF
--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -177,7 +177,7 @@ func (v *vimstate) BatchEnd() (res []json.RawMessage) {
 	if len(calls) == 0 {
 		return
 	}
-	vs := v.ChannelCall("s:batchCall", calls...)
+	vs := v.ChannelCall("s:batchCall", calls)
 	v.Parse(vs, &res)
 	return
 }

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -356,9 +356,9 @@ function GOVIM_internal_EnrichDelta(bufnr, start, end, added, changes)
   call GOVIM_internal_BufChanged(a:bufnr, a:start, a:end, a:added, a:changes)
 endfunction
 
-function s:batchCall(...)
+function s:batchCall(calls)
   let l:res = []
-  for l:call in a:000
+  for l:call in a:calls
     let F = function(l:call[0], l:call[1:-1])
     call add(l:res, F())
   endfor


### PR DESCRIPTION
Currently we define s:batchCall to take a variadic number of arguments.
This is unnecessary because it can take a single argument, a list. With
the signature being variadic, it also means we're likely to hit some
sort of Vim limit on the number of arguments that can be parsed.

This change changes the signature of that function to take a list,
thereby sidestepping all of these issues.