### PR TITLE
cmd/govim: provide an experiment config option for popup options

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -20,6 +20,49 @@ type Config struct {
 	// CommandQuickfixDiagnostics command can be used to manually trigger the
 	// population. Default: false (0)
 	QuickfixAutoDiagnosticsDisable bool
+
+	// ExperimentalMouseTriggeredHoverPopupOptions is a map of options to apply
+	// when creating hover-based popup windows triggered by the mouse hovering
+	// over an identifier. It corresponds to the second argument to popup_create
+	// (see :help popup_create-arguments). If set, these options define the
+	// options that will be used when creating hover popups. That is to say, the
+	// options set in ExperimentalMouseTriggeredHoverPopupOptions do no override
+	// defaults set in govim, the supplied map is used as is in the call to
+	// popup create. The only exceptions to this are the values of line and col.
+	// Because the position of the popup is relative to positin of where it was
+	// triggered, these values are interpreted as relative values. Hence a "line"
+	// value of -1 will mean the popup is placed on the line before the position
+	// at which the hover was triggered.
+	//
+	// The "filter" and "callback" options are not supported because they have a
+	// function-type value, and hence cannot be serialised to JSON.
+	//
+	// This is an experimental feature designed to help iterate on
+	// the most sensible out-of-the-box defaults for hover popups. It might go
+	// away in the future, be renamed etc.
+	ExperimentalMouseTriggeredHoverPopupOptions map[string]interface{}
+
+	// ExperimentalCursorTriggeredHoverPopupOptions is a map of options to apply
+	// when creating hover-based popup windows triggered by a call to
+	// GOVIMHover() which uses the cursor position for popup placement.  It
+	// corresponds to the second argument to popup_create (see :help
+	// popup_create-arguments). If set, these options define the options that
+	// will be used when creating hover popups. That is to say, the options set
+	// in ExperimentalCursorTriggeredHoverPopupOptions do no override defaults
+	// set in govim, the supplied map is used as is in the call to popup create.
+	// The only exceptions to this are the values of line and col.  Because the
+	// position of the popup is relative to positin of where it was triggered,
+	// these values are interpreted as relative values. Hence a "line" value of
+	// -1 will mean the popup is placed on the line before the position at which
+	// the hover was triggered.
+	//
+	// The "filter" and "callback" options are not supported because they have a
+	// function-type value, and hence cannot be serialised to JSON.
+	//
+	// This is an experimental feature designed to help iterate on the most
+	// sensible out-of-the-box defaults for hover popups. It might go away in
+	// the future, be renamed etc.
+	ExperimentalCursorTriggeredHoverPopupOptions map[string]interface{}
 }
 
 type Command string

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -65,13 +65,27 @@ type vimstate struct {
 
 func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 	var c struct {
-		FormatOnSave                   config.FormatOnSave
-		QuickfixAutoDiagnosticsDisable int
+		FormatOnSave                                 config.FormatOnSave
+		QuickfixAutoDiagnosticsDisable               int
+		ExperimentalMouseTriggeredHoverPopupOptions  map[string]json.RawMessage
+		ExperimentalCursorTriggeredHoverPopupOptions map[string]json.RawMessage
 	}
 	v.Parse(args[0], &c)
 	v.config = config.Config{
 		FormatOnSave:                   c.FormatOnSave,
 		QuickfixAutoDiagnosticsDisable: c.QuickfixAutoDiagnosticsDisable != 0,
+	}
+	if len(c.ExperimentalMouseTriggeredHoverPopupOptions) > 0 {
+		v.config.ExperimentalMouseTriggeredHoverPopupOptions = make(map[string]interface{})
+		for ck, cv := range c.ExperimentalMouseTriggeredHoverPopupOptions {
+			v.config.ExperimentalMouseTriggeredHoverPopupOptions[ck] = cv
+		}
+	}
+	if len(c.ExperimentalCursorTriggeredHoverPopupOptions) > 0 {
+		v.config.ExperimentalCursorTriggeredHoverPopupOptions = make(map[string]interface{})
+		for ck, cv := range c.ExperimentalCursorTriggeredHoverPopupOptions {
+			v.config.ExperimentalCursorTriggeredHoverPopupOptions[ck] = cv
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Whilst we try to establish the best defaults for popup windows in
various contexts (#360), let's provide experimental config options to
allow users to help with this experiment.

For example, to set the options for mouse-trigger hover popups, add the
following to your .vimrc:

call govim#config#Set("ExperimentalMouseTriggeredHoverPopupOptions", {
      \ "mousemoved": "any",
      \ "pos": "botleft",
      \ "line": -1,
      \ "col": 0,
      \ "moved": "any",
      \ "border": [],
      \ "wrap": v:false,
      \ "close": "click",
      \ "padding": [0, 1, 0, 1],
      \})

See the go doc for github.com/myitcv/govim/cmd/govim/config for more
details on what config options can be set.

See :help popup_create-arguments for details of the various options that
can be set for ExperimentalMouseTriggeredHoverPopupOptions and
ExperimentalCursorTriggeredHoverPopupOptions.

Whilst we are at it, also change the default popup to add some left and
right padding.