### PR TITLE
cmd/govim: fix bug in use of user provided hover popup options

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -120,7 +120,10 @@ func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface
 	msg := strings.TrimSpace(hovRes.Contents.Value)
 	lines := strings.Split(msg, "\n")
 	if userOpts != nil {
-		opts = userOpts
+		opts = make(map[string]interface{})
+		for k, v := range userOpts {
+			opts[k] = v
+		}
 		var line, col int64
 		var err error
 		if lv, ok := opts["line"]; ok {


### PR DESCRIPTION
We were not copying the may of user options when using it; instead we
were modifying the config in place.