### PR TITLE
cmd/govim: add padding to default hover popup window

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -144,6 +144,7 @@ func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface
 		opts["col"] = vpos.ScreenPos.Col
 		opts["mousemoved"] = "any"
 		opts["moved"] = "any"
+		opts["padding"] = []int{0, 1, 0, 1}
 		opts["wrap"] = false
 		opts["close"] = "click"
 	}


### PR DESCRIPTION
Left and right padding makes things look a little more comfortable (and
matches the behaviour of the omnifunc menu).

This change got missed in c79efa9a1bb9fbf1276d93b8702beadfb315de96.