### PR TITLE
cmd/govim: use winid instead of winnr for hover placement

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -12,7 +12,7 @@ import (
 
 func (v *vimstate) balloonExpr(args ...json.RawMessage) (interface{}, error) {
 	if v.usePopupWindows() {
-		posExpr := `{"bufnum": v:beval_bufnr, "line": v:beval_lnum, "col": v:beval_col, "screenpos": screenpos(v:beval_winnr, v:beval_lnum, v:beval_col)}`
+		posExpr := `{"bufnum": v:beval_bufnr, "line": v:beval_lnum, "col": v:beval_col, "screenpos": screenpos(v:beval_winid, v:beval_lnum, v:beval_col)}`
 		opts := map[string]interface{}{
 			"mousemoved": "any",
 		}
@@ -58,7 +58,7 @@ func (v *vimstate) balloonExpr(args ...json.RawMessage) (interface{}, error) {
 
 func (v *vimstate) hover(args ...json.RawMessage) (interface{}, error) {
 	if v.usePopupWindows() {
-		posExpr := `{"bufnum": bufnr(""), "line": line("."), "col": col("."), "screenpos": screenpos(winnr(), line("."), col("."))}`
+		posExpr := `{"bufnum": bufnr(""), "line": line("."), "col": col("."), "screenpos": screenpos(win_getid(), line("."), col("."))}`
 		opts := map[string]interface{}{
 			"mousemoved": "any",
 		}


### PR DESCRIPTION
We were incorrectly using window numbers instead of IDs for placement of
mouse-trigger and cursor-triggered hover popups. Fix that.