### PR TITLE
cmd/govim: replace batching implementation with something more robust

### DIFF
--- a/cmd/govim/testdata/batch.txt
+++ b/cmd/govim/testdata/batch.txt
@@ -1,0 +1,36 @@
+# Test that the various batch functions work in various permutations
+
+# Ensure that we can call a working batch function
+vim call GOVIMSimpleBatch
+stdout [5,4]
+! stderr .+
+
+# Now call a batch that cancels because nothing is done
+vim call GOVIMCancelBatch
+stdout '"did not run"'
+! stderr .+
+
+# Ensure that we can still call a working batch function
+vim call GOVIMSimpleBatch
+stdout [5,4]
+! stderr .+
+
+# Now call a function where there is an exception in the batch
+! vim call GOVIMBadBatch
+! stdout .+
+stderr 'failed to call GOVIMBadBatch\(\[\]\) in Vim: Caught ''got error whilst handling GOVIMBadBatch: driver error: ChannelCall\("s:batchCall"\) failed: failed to call s:batchCall\(\[\[\[call s:mustNothing execute throw "failed"\]\]\]\) in Vim: Caught ''''failed'''''
+
+# Ensure that we can still call a working batch function
+vim call GOVIMSimpleBatch
+stdout [5,4]
+! stderr .+
+
+# Now call a function where a batch assertion fails
+! vim call GOVIMAssertFailedBatch
+! stdout .+
+stderr 'failed to call GOVIMAssertFailedBatch\(\[\]\) in Vim: Caught ''got error whilst handling GOVIMAssertFailedBatch: driver error: ChannelCall\("s:batchCall"\) failed: failed to call s:batchCall\(\[\[\[expr s:mustBeZero 1\]\]\]\) in Vim: Caught ''''failed to eval 1: got non-zero return value'
+
+# Ensure that we can still call a working batch function
+vim call GOVIMSimpleBatch
+stdout [5,4]
+! stderr .+


### PR DESCRIPTION
The previous implementation of the cmd/govim Batch "API" was a rough
first cut. This makes the implementation more robust and adds tests.