### PR TITLE
cmd/govim: tidy up test definitions

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -26,7 +26,7 @@ func (v *vimstate) bufReadPost(args ...json.RawMessage) error {
 	} else {
 		// first time we have seen the buffer
 		if v.doIncrementalSync() {
-			b.Listener = v.ParseInt(v.ChannelCall("listener_add", v.Prefix()+config.FunctionEnrichDelta, b.Num))
+			b.Listener = v.ParseInt(v.ChannelCall("listener_add", v.Prefix()+string(config.FunctionEnrichDelta), b.Num))
 		}
 		b.Version = 0
 	}

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -3,7 +3,7 @@
 package config
 
 const (
-	internalFunctionPrefix = "_internal_"
+	InternalFunctionPrefix = "_internal_"
 )
 
 type Config struct {
@@ -77,10 +77,6 @@ const (
 	// CommandGoToPrevDef respects &switchbuf
 	CommandGoToPrevDef Command = "GoToPrevDef"
 
-	// CommandHello is a friendly command, largely for checking govim is
-	// working.
-	CommandHello Command = "Hello"
-
 	// CommandGoFmt applies gofmt to the entire buffer
 	CommandGoFmt Command = "GoFmt"
 
@@ -92,7 +88,7 @@ const (
 	CommandQuickfixDiagnostics Command = "QuickfixDiagnostics"
 
 	// CommandReferences finds references to the identifier under the cursor.
-	CommandReferences = "References"
+	CommandReferences Command = "References"
 )
 
 type Function string
@@ -100,40 +96,32 @@ type Function string
 const (
 	// FunctionBalloonExpr is an internal function used by govim for balloonexpr
 	// in Vim
-	FunctionBalloonExpr Function = internalFunctionPrefix + "BalloonExpr"
+	FunctionBalloonExpr Function = InternalFunctionPrefix + "BalloonExpr"
 
 	// FunctionComplete is an internal function used by govim as for omnifunc in
 	// Vim
-	FunctionComplete Function = internalFunctionPrefix + "Complete"
+	FunctionComplete Function = InternalFunctionPrefix + "Complete"
 
 	// FunctionHover returns the same text that would be returned by a
 	// mouse-based hover, but instead uses the cursor position for the
 	// identifier.
 	FunctionHover Function = "Hover"
 
-	// FunctionHello is a friendly function, largely for checking govim is
-	// working.
-	FunctionHello Function = "Hello"
-
 	// FunctionBufChanged is an internal function used by govim for handling
 	// delta-based changes in buffers.
-	FunctionBufChanged = internalFunctionPrefix + "BufChanged"
+	FunctionBufChanged Function = InternalFunctionPrefix + "BufChanged"
 
 	// FunctionEnrichDelta is an internal function used by govim for enriching
 	// listener_add based callbacks before calling FunctionBufChanged
-	FunctionEnrichDelta = internalFunctionPrefix + "EnrichDelta"
+	FunctionEnrichDelta Function = InternalFunctionPrefix + "EnrichDelta"
 
 	// FunctionSetConfig is an internal function used by govim for pushing config
 	// changes from Vim to govim.
-	FunctionSetConfig = internalFunctionPrefix + "SetConfig"
+	FunctionSetConfig Function = InternalFunctionPrefix + "SetConfig"
 
 	// FunctionSetUserBusy is an internal function used by govim for indicated
 	// whether the user is busy or not (based on cursor movement)
-	FunctionSetUserBusy = internalFunctionPrefix + "SetUserBusy"
-
-	// FunctionDumpPopups is an internal function used by govim tests for capturing
-	// the text in all visible popups
-	FunctionDumpPopups = internalFunctionPrefix + "DumpPopups"
+	FunctionSetUserBusy Function = InternalFunctionPrefix + "SetUserBusy"
 )
 
 // FormatOnSave typed constants define the set of valid values that

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -26,6 +26,10 @@ var (
 	fDebugLog = flag.Bool("debugLog", false, "whether to log debugging info from vim, govim and the test shim")
 )
 
+func init() {
+	exposeTestAPI = true
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
 		"vim":     testdriver.Vim,
@@ -165,6 +169,7 @@ func TestInstallScripts(t *testing.T) {
 				e.Vars = append(e.Vars,
 					"PLUGIN_PATH="+govimPath,
 					"CURRENT_GOPATH="+os.Getenv("GOPATH"),
+					testsetup.EnvLoadTestAPI+"=true",
 				)
 				return nil
 			},

--- a/cmd/govim/test_config.go
+++ b/cmd/govim/test_config.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/myitcv/govim"
+	"github.com/myitcv/govim/cmd/govim/config"
+)
+
+// This file contains config that would otherwise be in the
+// github.com/myitcv/govim/cmd/govim/config, but for the fact that these are
+// only definitions we need for the purposes of testing
+
+const (
+	CommandHello config.Command = "Hello"
+)
+
+const (
+	FunctionHello      config.Function = "Hello"
+	FunctionDumpPopups config.Function = config.InternalFunctionPrefix + "DumpPopups"
+)
+
+func (g *govimplugin) InitTestAPI() {
+	if !exposeTestAPI {
+		return
+	}
+
+	g.DefineFunction(string(FunctionHello), []string{}, g.vimstate.hello)
+	g.DefineCommand(string(CommandHello), g.vimstate.helloComm)
+	g.DefineFunction(string(FunctionDumpPopups), []string{}, g.vimstate.dumpPopups)
+}
+
+func (v *vimstate) hello(args ...json.RawMessage) (interface{}, error) {
+	return "Hello from function", nil
+}
+
+func (v *vimstate) helloComm(flags govim.CommandFlags, args ...string) error {
+	v.ChannelEx(`echom "Hello from command"`)
+	return nil
+}
+
+func (v *vimstate) dumpPopups(args ...json.RawMessage) (interface{}, error) {
+	var bufInfo []struct {
+		BufNr  int   `json:"bufnr"`
+		Popups []int `json:"popups"`
+	}
+	bi := v.ChannelExpr("getbufinfo()")
+	v.Parse(bi, &bufInfo)
+	sort.Slice(bufInfo, func(i, j int) bool {
+		return bufInfo[i].BufNr < bufInfo[j].BufNr
+	})
+	var sb strings.Builder
+	for _, b := range bufInfo {
+		if len(b.Popups) == 0 {
+			continue
+		}
+		sb.WriteString(v.ParseString(v.ChannelExprf(`join(getbufline(%v, 0, '$'), "\n")."\n"`, b.BufNr)))
+	}
+	return sb.String(), nil
+}

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -3,10 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"strings"
 
-	"github.com/myitcv/govim"
 	"github.com/myitcv/govim/cmd/govim/config"
 	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
 	"github.com/myitcv/govim/cmd/govim/types"
@@ -90,15 +87,6 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 	return nil, nil
 }
 
-func (v *vimstate) hello(args ...json.RawMessage) (interface{}, error) {
-	return "Hello from function", nil
-}
-
-func (v *vimstate) helloComm(flags govim.CommandFlags, args ...string) error {
-	v.ChannelEx(`echom "Hello from command"`)
-	return nil
-}
-
 func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 	var isBusy int
 	v.Parse(args[0], &isBusy)
@@ -107,26 +95,6 @@ func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 		return nil, nil
 	}
 	return nil, v.updateQuickfix()
-}
-
-func (v *vimstate) dumpPopups(args ...json.RawMessage) (interface{}, error) {
-	var bufInfo []struct {
-		BufNr  int   `json:"bufnr"`
-		Popups []int `json:"popups"`
-	}
-	bi := v.ChannelExpr("getbufinfo()")
-	v.Parse(bi, &bufInfo)
-	sort.Slice(bufInfo, func(i, j int) bool {
-		return bufInfo[i].BufNr < bufInfo[j].BufNr
-	})
-	var sb strings.Builder
-	for _, b := range bufInfo {
-		if len(b.Popups) == 0 {
-			continue
-		}
-		sb.WriteString(v.ParseString(v.ChannelExprf(`join(getbufline(%v, 0, '$'), "\n")."\n"`, b.BufNr)))
-	}
-	return sb.String(), nil
 }
 
 func (v *vimstate) BatchStart() {

--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -21,6 +21,7 @@ const (
 	EnvGithubUser  = "GH_USER"
 	EnvGithubToken = "GH_TOKEN"
 
+	EnvLoadTestAPI               = "GOVIM_LOAD_TEST_API"
 	EnvDisableIncrementalSync    = "GOVIM_DISABLE_INCREMENTALSYNC"
 	EnvDisablePopupWindowBalloon = "GOVIM_DISABLE_POPUPWINDOWBALLOON"
 


### PR DESCRIPTION
When testing cmd/govim we define certain functions, commands and
autocommands that are only required for testing purposes. Tidy these
into a separate file and use a nasty/nifty hack to only load these when
running tests.