### PR TITLE
[WIP] cmd/govim: add signs to quickfix entries (#284)

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -206,6 +206,11 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineFunction(string(config.FunctionSetUserBusy), []string{"isBusy"}, g.vimstate.setUserBusy)
 	g.DefineCommand(string(config.CommandReferences), g.vimstate.references)
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
+	if g.placeSigns() {
+		if err := g.vimstate.signDefine(); err != nil {
+			return fmt.Errorf("failed to define signs: %v", err)
+		}
+	}
 
 	g.InitTestAPI()
 
@@ -354,6 +359,19 @@ func (g *govimplugin) usePopupWindows() bool {
 		return false
 	}
 	if os.Getenv(testsetup.EnvDisablePopupWindowBalloon) == "true" {
+		return false
+	}
+	return true
+}
+
+func (g *govimplugin) placeSigns() bool {
+	if g.Flavor() != govim.FlavorVim && g.Flavor() != govim.FlavorGvim {
+		return false
+	}
+	if semver.Compare(g.Version(), testsetup.MinSignPlace) < 0 {
+		return false
+	}
+	if os.Getenv(testsetup.EnvDisableSignPlace) == "true" {
 		return false
 	}
 	return true

--- a/cmd/govim/quickfix.go
+++ b/cmd/govim/quickfix.go
@@ -18,6 +18,7 @@ type quickfixEntry struct {
 	Lnum     int    `json:"lnum"`
 	Col      int    `json:"col"`
 	Text     string `json:"text"`
+	Buf      int    `json:"buf"`
 }
 
 func (v *vimstate) quickfixDiagnostics(flags govim.CommandFlags, args ...string) error {
@@ -81,6 +82,7 @@ func (v *vimstate) updateQuickfix(args ...json.RawMessage) error {
 				Lnum:     p.Line(),
 				Col:      p.Col(),
 				Text:     d.Message,
+				Buf:      buf.Num,
 			})
 		}
 	}
@@ -96,5 +98,11 @@ func (v *vimstate) updateQuickfix(args ...json.RawMessage) error {
 		return cmp < 0
 	})
 	v.ChannelCall("setqflist", fixes, "r")
+
+	if v.placeSigns() {
+		if err := v.redefineSigns(fixes); err != nil {
+			v.Logf("updateQuickfix: failed to place/remove signs: %v", err)
+		}
+	}
 	return nil
 }

--- a/cmd/govim/signs.go
+++ b/cmd/govim/signs.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+)
+
+// Using a sign group creates a separate namespace for all signs placed by govim
+const signGroup = "govim"
+
+type signDef struct {
+	name          string // Name of the sign
+	text          string // One or two chars shown in the gutter
+	textHighlight string // Highlight used
+}
+
+// Only one sign type at the moment, errors.
+var errorSign = signDef{"govimerr", ">>", "Error"}
+
+// signDefine defines the govim error sign and must be called once before placing any signs
+func (v *vimstate) signDefine() error {
+	argDict := struct {
+		Text          string `json:"text"`
+		TextHighlight string `json:"texthl"`
+	}{errorSign.text, errorSign.textHighlight}
+
+	if v.ParseInt(v.ChannelCall("sign_define", errorSign.name, argDict)) != 0 {
+		return fmt.Errorf("sign_define failed")
+	}
+	return nil
+}
+
+// bufferSigns represents a single element in the response from a sign_getplaced() call
+type bufferSigns struct {
+	Signs []struct {
+		Lnum  int    `json:"lnum"`
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Prio  int    `json:"priority"`
+		Group string `json:"group"`
+	} `json:"signs"`
+	BufNr int `json:"bufnr"`
+}
+
+// signGetPlaced returns all signs placed by govim in a specific buffer
+func (v *vimstate) signGetPlaced(buf int) (bufferSigns, error) {
+	argDict := struct {
+		Group string `json:"group"`
+	}{signGroup}
+	resp := v.ParseJSONArgSlice(v.ChannelCall("sign_getplaced", buf, argDict))
+
+	if len(resp) != 1 {
+		// Should never get here since sign_getplaced is called with a single buffer as argument
+		return bufferSigns{}, fmt.Errorf("sign_getplaced failed")
+	}
+
+	var out bufferSigns
+	v.Parse(resp[0], &out)
+	return out, nil
+}
+
+// placeDict is the representation of arguments used in vim's sign_place() and sign_placelist()
+type placeDict struct {
+	Buffer int    `json:"buffer"`          // sign_placelist() only
+	Group  string `json:"group,omitempty"` // sign_placelist() only
+	ID     int    `json:"id,omitempty"`    // sign_placelist() only
+	Lnum   int    `json:"lnum,omitempty"`
+	Name   string `json:"name"` // sign_placelist() only
+	Prio   int    `json:"priority,omitempty"`
+}
+
+// unplaceDict is the representation of arguments used in vim's sign_unplace() and sign_unplacelist()
+type unplaceDict struct {
+	Buffer int    `json:"buffer,omitempty"`
+	Group  string `json:"group,omitempty"` // sign_unplacelist() only
+	ID     int    `json:"id,omitempty"`
+}
+
+// redefineSigns ensures that there is only one govim sign per buffer and line
+// by calculating a difference between current state and the list of quickfix entries
+func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
+	type bufLine struct {
+		buf  int
+		line int
+	}
+	remove := make(map[bufLine]int) // Value is sign ID, used to unplace duplicates
+	place := make(map[bufLine]int)  // Value is insert order, used to avoid sorting
+
+	// Assume all existing signs should be removed, unless found in quickfix entry list
+	for buf := range v.buffers {
+		placed, _ := v.signGetPlaced(buf)
+		for _, sign := range placed.Signs {
+			bl := bufLine{placed.BufNr, sign.Lnum}
+			if _, exist := remove[bl]; exist {
+				// As each sign isn't tracked individually, we might end up with several
+				// signs on the same line when, for example, a line is removed.
+				// By removing duplicates here we ensure that there is only one
+				// sign per line.
+				v.ChannelCall("sign_unplace", signGroup, unplaceDict{Buffer: bl.buf, ID: sign.ID})
+				continue
+			}
+			remove[bl] = sign.ID
+		}
+	}
+
+	// Add signs for quickfix entry lines that doesn't already have a sign, and
+	// delete existing entries from the list of signs to removed
+	inx := 0
+	for _, f := range fixes {
+		bl := bufLine{f.Buf, f.Lnum}
+		if _, exist := remove[bl]; exist {
+			delete(remove, bl)
+			continue
+		}
+
+		if bl.buf == -1 {
+			continue // Don't place signs in unknown buffers
+		}
+
+		if _, exist := place[bl]; !exist {
+			place[bl] = inx
+			inx++
+		}
+	}
+
+	if len(place) > 0 {
+		placeList := make([]placeDict, len(place))
+		// Use insert order as index to avoid sorting
+		for bl, i := range place {
+			placeList[i] = placeDict{
+				Buffer: bl.buf,
+				Group:  signGroup,
+				Lnum:   bl.line,
+				Name:   errorSign.name}
+		}
+
+		v.ChannelCall("sign_placelist", placeList)
+	}
+
+	// Remove signs on all lines that didn't have a corresponding quickfix entry
+	if len(remove) > 0 {
+		unplaceList := make([]unplaceDict, 0, len(remove))
+		for bl, id := range remove {
+			unplaceList = append(unplaceList, unplaceDict{Buffer: bl.buf, Group: signGroup, ID: id})
+		}
+		v.ChannelCall("sign_unplacelist", unplaceList)
+	}
+	return nil
+}

--- a/cmd/govim/testdata/signs.txt
+++ b/cmd/govim/testdata/signs.txt
@@ -1,0 +1,129 @@
+# Test that signs are placed/removed as quickfix entries are updated. There are four entries from the start:
+#   main.go|6 col 36| undeclared name: i
+#   main.go|6 col 39| undeclared name: v
+#   main.go|9 col 19| missing return
+#   main.go|10 col 19| missing return
+
+# Since signs are placed/removed using sign_placelist()/sign_unplacelist() they require v8.1.1682.
+[vim] [!vim:v8.1.1652] skip
+[gvim] [!gvim:v8.1.1652] skip
+
+vim ex 'e main.go'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+
+# Assert that the error sign is defined
+vim -indent expr 'sign_getdefined()'
+! stderr .+
+cmp stdout defined.golden
+
+
+# There must be only one sign per line
+vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed_openfile.golden
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+
+
+# Removing one of the two quickfix entires on one line shouldn't remove the sign
+vim ex 'call cursor(6,36)'
+vim ex 'call feedkeys(\"3x\", \"x\")' # Remove "i, " from Printf-line
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed_openfile.golden
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+
+
+# Removing lines should also remove the signs
+vim ex 'call cursor(9,1)'
+vim ex 'call feedkeys(\"2dd\", \"x\")' # Remove line 9 & 10
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed_onesign.golden
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+
+
+# Fixing the last quickfix entry should remove the last sign
+vim call append '[5, "\tvar v string"]'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed_nosign.golden
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("This is a test %v\n", i, v)
+}
+
+func f1() string {}
+func f2() string {}
+
+-- defined.golden --
+[
+  {
+    "name": "govimerr",
+    "text": "\u003e\u003e",
+    "texthl": "Error"
+  }
+]
+-- placed_openfile.golden --
+[
+  {
+    "bufnr": 1,
+    "signs": [
+      {
+        "group": "govim",
+        "id": 1,
+        "lnum": 6,
+        "name": "govimerr",
+        "priority": 10
+      },
+      {
+        "group": "govim",
+        "id": 2,
+        "lnum": 9,
+        "name": "govimerr",
+        "priority": 10
+      },
+      {
+        "group": "govim",
+        "id": 3,
+        "lnum": 10,
+        "name": "govimerr",
+        "priority": 10
+      }
+    ]
+  }
+]
+-- placed_onesign.golden --
+[
+  {
+    "bufnr": 1,
+    "signs": [
+      {
+        "group": "govim",
+        "id": 1,
+        "lnum": 6,
+        "name": "govimerr",
+        "priority": 10
+      }
+    ]
+  }
+]
+-- placed_nosign.golden --
+[
+  {
+    "bufnr": 1,
+    "signs": []
+  }
+]

--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -24,6 +24,7 @@ const (
 	EnvLoadTestAPI               = "GOVIM_LOAD_TEST_API"
 	EnvDisableIncrementalSync    = "GOVIM_DISABLE_INCREMENTALSYNC"
 	EnvDisablePopupWindowBalloon = "GOVIM_DISABLE_POPUPWINDOWBALLOON"
+	EnvDisableSignPlace          = "GOVIM_DISABLE_SIGNPLACE"
 
 	// MinVimGovim represents the bare minimum version of Vim required to
 	// use govim
@@ -36,6 +37,10 @@ const (
 	// MinPopupWindowBalloon is the minimum version of Vim required to use popup
 	// windows for balloons
 	MinPopupWindowBalloon = "v8.1.1657"
+
+	// MinSignPlace is the minimum version of Vim required to use
+	// sign placement (i.e. supports sign_placelist() / sign_unplacelist())
+	MinSignPlace = "v8.1.1682"
 
 	EnvLogfileTmpl      = "GOVIM_LOGFILE_TMPL"
 	EnvTestscriptStderr = "GOVIM_TESTSCRIPT_STDERR"


### PR DESCRIPTION
Closes #284 

This PR will place one sign on each line where there is a quickfix entry. It superseeds PR #366 since vim now supports placing and removing several signs in a single call and that works better than batching as far as I've seen.