### PR TITLE
cmd/govim: initial cut of GOVIMStringFn command

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -94,6 +94,19 @@ const (
 	// argument, that argument is used as the new name. If not, the user is
 	// prompted for the new identifier name.
 	CommandRename Command = "Rename"
+
+	// CommandStringFn applies a transformation function to text. Without a
+	// range the current line is used as input. Visual ranges can also be used,
+	// with the exception of visual blocks. The command takes one or more
+	// arguments: the transformation functions to apply. Tab completion can be
+	// used to complete against the defined transformation functions.
+	//
+	// The goal with this command is to expose standard library functions to
+	// help manipulate text. Wherever possible, functions will directly map to
+	// their standard library equivalents, for example, strconv.Quote. In this
+	// case, the format is $importpath.$function. In some situations, poetic
+	// license may be required.
+	CommandStringFn Command = "StringFn"
 )
 
 type Function string
@@ -127,6 +140,10 @@ const (
 	// FunctionSetUserBusy is an internal function used by govim for indicated
 	// whether the user is busy or not (based on cursor movement)
 	FunctionSetUserBusy Function = InternalFunctionPrefix + "SetUserBusy"
+
+	// FunctionStringFnComplete is an internal function used by govim to provide
+	// completion of arguments to CommandStringFn
+	FunctionStringFnComplete Function = InternalFunctionPrefix + "StringFnComplete"
 )
 
 // FormatOnSave typed constants define the set of valid values that

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -202,10 +202,12 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandQuickfixDiagnostics), g.vimstate.quickfixDiagnostics)
 	g.DefineFunction(string(config.FunctionBufChanged), []string{"bufnr", "start", "end", "added", "changes"}, g.vimstate.bufChanged)
 	g.DefineFunction(string(config.FunctionSetConfig), []string{"config"}, g.vimstate.setConfig)
-	g.ChannelExf(`call govim#config#Set("_internal_Func", function("%v%v"))`, PluginPrefix, config.FunctionSetConfig)
+	g.ChannelExf(`call govim#config#Set("%vFunc", function("%v%v"))`, config.InternalFunctionPrefix, PluginPrefix, config.FunctionSetConfig)
 	g.DefineFunction(string(config.FunctionSetUserBusy), []string{"isBusy"}, g.vimstate.setUserBusy)
 	g.DefineCommand(string(config.CommandReferences), g.vimstate.references)
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
+	g.DefineCommand(string(config.CommandStringFn), g.vimstate.stringfns, govim.RangeLine, govim.CompleteCustomList(PluginPrefix+config.FunctionStringFnComplete), govim.NArgsOneOrMore)
+	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)
 
 	g.InitTestAPI()
 

--- a/cmd/govim/stringfns.go
+++ b/cmd/govim/stringfns.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/myitcv/govim"
+	"github.com/myitcv/govim/cmd/govim/config"
+	"github.com/myitcv/govim/cmd/govim/internal/lsp/protocol"
+	"github.com/myitcv/govim/cmd/govim/types"
+)
+
+var stringFns = map[string]interface{}{
+	"strconv.Quote":               strconv.Quote,
+	"strconv.Unquote":             strconv.Unquote,
+	"regexp.QuoteMeta":            regexp.QuoteMeta,
+	"crypto/sha256.Sum256":        sha256Sum,
+	"encoding/hex.EncodeToString": hexEncode,
+}
+
+func (v *vimstate) stringfns(flags govim.CommandFlags, args ...string) error {
+	var transFns []interface{}
+	for _, fp := range args {
+		fn, ok := stringFns[fp]
+		if !ok {
+			return fmt.Errorf("failed to resolve transformation function %q", fp)
+		}
+		transFns = append(transFns, fn)
+	}
+	var err error
+	var start, end types.Point
+	var b *types.Buffer
+	switch *flags.Range {
+	case 2:
+		// we have a range
+		var pos struct {
+			BuffNr int    `json:"buffnr"`
+			Mode   string `json:"mode"`
+			Start  []int  `json:"start"`
+			End    []int  `json:"end"`
+		}
+		v.Parse(v.ChannelExpr(`{"buffnr": bufnr(""), "mode": visualmode(), "start": getpos("'<"), "end": getpos("'>")}`), &pos)
+
+		if pos.Mode == "\x16" {
+			return fmt.Errorf("cannot use %v in visual block mode", config.CommandStringFn)
+		}
+
+		var ok bool
+		b, ok = v.buffers[pos.BuffNr]
+		if !ok {
+			return fmt.Errorf("failed to derive buffer")
+		}
+
+		start, err = types.PointFromVim(b, pos.Start[1], pos.Start[2])
+		if err != nil {
+			return fmt.Errorf("failed to get start position of range: %v", err)
+		}
+		if pos.Mode == "V" {
+			// we have already parsed start so we can mutate here
+			pos.End = pos.Start
+			pos.End[1]++
+		}
+		end, err = types.PointFromVim(b, pos.End[1], pos.End[2])
+		if err != nil {
+			return fmt.Errorf("failed to get end position of range: %v", err)
+		}
+		if pos.Mode == "v" {
+			// we need to move past the end of the selection
+			rem := b.Contents()[end.Offset():]
+			if len(rem) > 0 {
+				_, adj := utf8.DecodeRune(rem)
+				end, err = types.PointFromVim(b, pos.End[1], pos.End[2]+adj)
+				if err != nil {
+					return fmt.Errorf("failed to get adjusted end position: %v", err)
+				}
+			}
+		}
+	case 0:
+		// current line
+		b, _, err = v.cursorPos()
+		if err != nil {
+			return fmt.Errorf("failed to get cursor position for line range")
+		}
+		start, err = types.PointFromVim(b, *flags.Line1, 1)
+		if err != nil {
+			return fmt.Errorf("failed to get start position of range: %v", err)
+		}
+		end, err = types.PointFromVim(b, *flags.Line1+1, 1)
+		if err != nil {
+			return fmt.Errorf("failed to get end position of range: %v", err)
+		}
+	default:
+		return fmt.Errorf("unknown range indicator %v", *flags.Range)
+	}
+
+	endOffset := end.Offset()
+	if *flags.Range == 0 {
+		endOffset--
+	}
+	newText := string(b.Contents()[start.Offset():endOffset])
+	for fp, fn := range transFns {
+		switch fn := fn.(type) {
+		case func(string) string:
+			newText = fn(string(newText))
+		default:
+			return fmt.Errorf("do not know how to handle transformation function %q of type %T", fp, fn)
+		}
+	}
+	if *flags.Range == 0 {
+		newText += "\n"
+	}
+
+	edit := protocol.TextEdit{
+		Range: protocol.Range{
+			Start: start.ToPosition(),
+			End:   end.ToPosition(),
+		},
+		NewText: newText,
+	}
+	return v.applyProtocolTextEdits(b, []protocol.TextEdit{edit})
+}
+
+func (v *vimstate) stringfncomplete(args ...json.RawMessage) (interface{}, error) {
+	lead := v.ParseString(args[0])
+	var results []string
+	for k := range stringFns {
+		if strings.HasPrefix(k, lead) {
+			results = append(results, k)
+		}
+	}
+	sort.Strings(results)
+	return results, nil
+}
+
+func sha256Sum(s string) string {
+	v := sha256.Sum256([]byte(s))
+	return string(v[:])
+}
+
+func hexEncode(s string) string {
+	return hex.EncodeToString([]byte(s))
+}

--- a/cmd/govim/testdata/stringfn.txt
+++ b/cmd/govim/testdata/stringfn.txt
@@ -1,0 +1,49 @@
+# Test that GOVIMStringFn works
+
+# No range
+vim ex 'e main.go'
+vim ex 'call cursor(7,1) | GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString'
+vim ex 'w'
+cmp main.go main.go.golden1
+
+# With a visual selection
+
+# Skip for now because for some reason we can't get the commands
+# to play ball, even though doing this by hand works
+skip
+
+vim ex 'call cursor(6,15)'
+#vim ex ':execute \"normal ve\" | ''<,''>GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString'
+#vim ex 'call cursor(6,15) | execute \"normal ve\" | :''<,''>GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString'
+vim ex 'call cursor(6,15)'
+vim ex 'execute \"normal ve\"'
+vim ex '''<,''>GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString'
+#vim ex 'call feedkeys(\"ve:GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString\", \"xt\")'
+vim ex 'w'
+cmp main.go main.go.golden
+
+-- go.mod --
+module mod
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(`
+test
+`)
+	fmt.Println("test")
+}
+-- main.go.golden1 --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(`
+9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+`)
+	fmt.Println("test")
+}


### PR DESCRIPTION
```
GOVIMStringFns is a command that replaces buffer text with the result of
applying a sequence of transformation functions. With no range, the
current line is used as input. That is to say the current line is used
as the argument to the sequence of transformation functions.  Visual
selections can also be used to specify the range, however the command
has no meaning for visual blocks.

The command takes one or more arguments: the sequence of transformation
functions to apply. Each argument is a path to a transformation
function, e.g. strconv.Quote

Here is an example of applying multiple transformations to a visual
selection:

:'<,'>GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString

The goal with this command is to expose standard library functions to
help manipulate text. Wherever possible, functions will directly map to
their standard library equivalents, for example, strconv.Quote. In this
case, the format is $importpath.$function. In some situations, poetic
license may be required.

When invoking the command, tab completion can be used against the known
transformation functions.

For now we hand-define a couple of obvious transformation functions. In
future PRs we may look to code generate this mapping, as well as writing
string-based wrappers around things like sha256 hash calculations.

Closes #273
```