### PR TITLE
cmd/govim: fix bug handling edits at end of files

### DIFF
--- a/cmd/govim/testdata/gofmt_eof.txt
+++ b/cmd/govim/testdata/gofmt_eof.txt
@@ -1,0 +1,31 @@
+# This test ensures that formatting changes at the end of a file works as
+# expected. It should probably be replaced by a suite of []protocol.TextEdit
+# tests
+
+vim ex 'e main.go'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim ex 'w'
+cmp main.go main.go.golden
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+func main() {
+	println("Hello, world!")
+}
+
+
+
+
+
+
+
+-- main.go.golden --
+package main
+
+func main() {
+	println("Hello, world!")
+}


### PR DESCRIPTION
Also add a simple test for now to cover this. We should, per the comment
in the testscript, add a suite of tests to properly cover
[]protocol.TextEdit changes in various scenarios.