### PR TITLE
scripts: fix GOPATH in runDockerRun.sh

### DIFF
--- a/_scripts/runDockerRun.sh
+++ b/_scripts/runDockerRun.sh
@@ -10,7 +10,7 @@ proxy=""
 
 if [ "${CI:-}" != "true" ]
 then
-	proxy="-v $GOPATH/pkg/mod/cache/download:/cache -e GOPROXY=file:///cache"
+	proxy="-v $(go env GOPATH)/pkg/mod/cache/download:/cache -e GOPROXY=file:///cache"
 fi
 
 docker run $proxy --env-file ./_scripts/.docker_env_file -e "VIM_FLAVOR=${VIM_FLAVOR:-vim}" -v $PWD:/home/$USER/govim -w /home/$USER/govim --rm govim ./_scripts/dockerRun.sh

--- a/_scripts/runDockerRun.sh
+++ b/_scripts/runDockerRun.sh
@@ -10,7 +10,8 @@ proxy=""
 
 if [ "${CI:-}" != "true" ]
 then
-	proxy="-v $(go env GOPATH)/pkg/mod/cache/download:/cache -e GOPROXY=file:///cache"
+	modcache="$(go env GOPATH | sed -e 's/:/\n/' | head -n 1)/pkg/mod/cache/download"
+	proxy="-v $modcache:/cache -e GOPROXY=file:///cache"
 fi
 
 docker run $proxy --env-file ./_scripts/.docker_env_file -e "VIM_FLAVOR=${VIM_FLAVOR:-vim}" -v $PWD:/home/$USER/govim -w /home/$USER/govim --rm govim ./_scripts/dockerRun.sh


### PR DESCRIPTION
Go doesn't require the env var GOPATH to be set since 1.8, `go env GOPATH` will however report the correct one even if it isn't set.