### PR TITLE
prepopulate mod cache before using it as proxy

### DIFF
--- a/_scripts/runDockerRun.sh
+++ b/_scripts/runDockerRun.sh
@@ -10,6 +10,7 @@ proxy=""
 
 if [ "${CI:-}" != "true" ]
 then
+	go mod download
 	modcache="$(go env GOPATH | sed -e 's/:/\n/' | head -n 1)/pkg/mod/cache/download"
 	proxy="-v $modcache:/cache -e GOPROXY=file:///cache"
 fi


### PR DESCRIPTION
The mod cache needs to be filled before using it as proxy since the GOPROXY can't be configured with fallback pre Go 1.13.

This PR will fill it before mounting it into the container.

Closes #404 