### PR TITLE
internal/plugin: tidy up shutdown errors

### DIFF
--- a/channel_cmds.go
+++ b/channel_cmds.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"gopkg.in/tomb.v2"
 )
 
 func (g *govimImpl) handleChannelError(ch unscheduledCallback, err error, format string, args ...interface{}) error {
@@ -126,9 +124,6 @@ func (g *govimImpl) DoProto(f func() error) (err error) {
 				}
 				err = r
 			case error:
-				if r == tomb.ErrDying {
-					panic(ErrShuttingDown)
-				}
 				if r == ErrShuttingDown {
 					panic(r)
 				}

--- a/event_queue.go
+++ b/event_queue.go
@@ -3,8 +3,6 @@ package govim
 import (
 	"encoding/json"
 	"fmt"
-
-	"gopkg.in/tomb.v2"
 )
 
 type eventQueueInst struct {
@@ -63,11 +61,11 @@ func (e eventQueueInst) handleUserQValueAndError(ch scheduledCallback, err error
 	args = append([]interface{}{}, args...)
 	select {
 	case <-e.govimImpl.tomb.Dying():
-		return nil, tomb.ErrDying
+		return nil, ErrShuttingDown
 	case e.flushEvents <- struct{}{}:
 		select {
 		case <-e.govimImpl.tomb.Dying():
-			panic(tomb.ErrDying)
+			return nil, ErrShuttingDown
 		case resp := <-ch:
 			if resp.errString != "" {
 				args = append(args, resp.errString)


### PR DESCRIPTION
Currently we muddle up tomb.ErrDying errors with govim.ErrShuttingDown.
We only need one of these to indicate that govim is shutting down, and
it should be the latter; the former is an implementation detail.

As part of this tidy up, we also fix a bug in internal/plugin where we
were incorrectly wrapping as an ErrDriver an error caused by govim
shutting down. Given the simplification to now only use
govim.ErrShuttingDown to indicate the mode/event, we simply check we
aren't shutting down before otherwise creating a wrapped error.

Fixes #406