### PR TITLE
cmd/govim: add signcolumn=yes to minimal vimrc

### DIFF
--- a/cmd/govim/config/minimal.vimrc
+++ b/cmd/govim/config/minimal.vimrc
@@ -31,3 +31,9 @@ set updatetime=500
 " Suggestion: To make govim/Vim more responsive/IDE-like, we suggest a short
 " balloondelay
 set balloondelay=250
+
+" Suggestion: Turn on the sign column so you can see error marks on lines
+" where there are quickfix errors. Some users who already show line number
+" might prefer to instead have the signs shown in the number column; in which
+" case set signcolumn=number (requires Vim >= v8.1.1564)
+set signcolumn=yes


### PR DESCRIPTION
The out-of-the-box experience should be that the sign column is visible,
so as to prevent the dance of it (the sign column)
appearing/disappearing as errors come and go.