### PR TITLE
cmd/govim fix test failures for scripts that use test_setmouse

### DIFF
--- a/cmd/govim/testdata/hover.txt
+++ b/cmd/govim/testdata/hover.txt
@@ -7,7 +7,7 @@
 [!vim:v8.1.1649] skip
 
 vim ex 'e main.go'
-vim ex 'call test_setmouse(6,13)'
+vim ex 'call test_setmouse(screenpos(bufwinid(\"main.go\"),6,13)[\"row\"],screenpos(bufwinid(\"main.go\"),6,13)[\"col\"])'
 vim ex 'call feedkeys(\"\\<MouseMove>\\<Ignore>\", \"xt\")'
 sleep 500ms
 vim -stringout expr 'GOVIM_internal_DumpPopups()'

--- a/cmd/govim/testdata/mapping_defaults_go_to_def.txt
+++ b/cmd/govim/testdata/mapping_defaults_go_to_def.txt
@@ -46,7 +46,7 @@ stdout '^\Q[3,15]\E$'
 [!vim:v8.1.1262] skip 'Need at least v8.1.1262 for test_setmouse'
 
 # <C-LeftMouse> and <C-RightMouse>
-vim ex 'call test_setmouse(3,15)'
+vim ex 'call test_setmouse(screenpos(bufwinid(\"p.go\"),3,15)[\"row\"],screenpos(bufwinid(\"p.go\"),3,15)[\"col\"])'
 vim ex 'call feedkeys(\"\\<C-LeftMouse>\", \"x\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[4,7]\E$'
@@ -55,7 +55,7 @@ vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[3,15]\E$'
 
 # g<LeftMouse> and g<RightMouse>
-vim ex 'call test_setmouse(3,15)'
+vim ex 'call test_setmouse(screenpos(bufwinid(\"p.go\"),3,15)[\"row\"],screenpos(bufwinid(\"p.go\"),3,15)[\"col\"])'
 vim ex 'call feedkeys(\"g\\<LeftMouse>\", \"x\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[4,7]\E$'


### PR DESCRIPTION
In 0404c34fe3a519a751240a40088e2c0f73f2a2fa I incorrectly attributed
test failures in cmd/govim/testdata/hover.txt and
cmd/govim/testdata/mapping_defaults_go_to_def.txt to flakes. These were
genuine failures. The change in that commit means that the signcolumn
will always be visible.

test_setmouse takes a _screen_ position. Therefore, turning on the
signcolumn meant that the screen position for positions in a buffer
shifted.

This kind of worked by accident before; we now use screenpos() to more
precisely set the mouse position.

Fixes #415
Fixes #416