### PR TITLE
deps: x/tools and gopls ff9f1409240a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -60,12 +60,21 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.Conn.Run(ctx)
 }
 
+type serverState int
+
+const (
+	serverCreated      = serverState(iota)
+	serverInitializing // set once the server has received "initialize" request
+	serverInitialized  // set once the server has received "initialized" request
+	serverShutDown
+)
+
 type Server struct {
 	Conn   *jsonrpc2.Conn
 	client protocol.Client
 
 	initializedMu sync.Mutex
-	isInitialized bool // set once the server has received "initialize" request
+	state         serverState
 
 	// Configurations.
 	// TODO(rstambler): Separate these into their own struct?

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/suggested_fix_experimental.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/suggested_fix_experimental.go
@@ -8,10 +8,10 @@ import (
 	"github.com/myitcv/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
-func getCodeActions(fset *token.FileSet, diag analysis.Diagnostic) ([]CodeAction, error) {
-	var cas []CodeAction
+func getCodeActions(fset *token.FileSet, diag analysis.Diagnostic) ([]SuggestedFixes, error) {
+	var cas []SuggestedFixes
 	for _, fix := range diag.SuggestedFixes {
-		var ca CodeAction
+		var ca SuggestedFixes
 		ca.Title = fix.Message
 		for _, te := range fix.TextEdits {
 			span, err := span.NewRange(fset, te.Pos, te.End).Span()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
@@ -31,6 +31,9 @@ func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFold
 }
 
 func (s *Server) addView(ctx context.Context, name string, uri span.URI) error {
-	s.session.NewView(ctx, name, uri)
+	view := s.session.NewView(ctx, name, uri)
+	if s.state >= serverInitialized {
+		s.fetchConfig(ctx, view)
+	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/rogpeppe/go-internal v1.3.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
-	golang.org/x/tools v0.0.0-20190727173135-db2fa46ec33c
-	golang.org/x/tools/gopls v0.1.4-0.20190727173135-db2fa46ec33c
+	golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a
+	golang.org/x/tools/gopls v0.1.4-0.20190729092621-ff9f1409240a
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	honnef.co/go/tools v0.0.0-20190614002413-cb51c254f01b

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,10 @@ golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190530171427-2b03ca6e44eb/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190723021737-8bb11ff117ca/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
-golang.org/x/tools v0.0.0-20190727173135-db2fa46ec33c h1:NrEU3v+Wvf1J+Ne0gtb6OYmJiCDC4GDcup2dtt2ldPo=
-golang.org/x/tools v0.0.0-20190727173135-db2fa46ec33c/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
-golang.org/x/tools/gopls v0.1.4-0.20190727173135-db2fa46ec33c h1:fJgxyhnVhPzWeYcDQjnpog8kyXNlIfbwCNRm9Q5wHmU=
-golang.org/x/tools/gopls v0.1.4-0.20190727173135-db2fa46ec33c/go.mod h1:u62zQD3pdNzbxmFIPWkvznqcaE5DWFAf2KUGsCtycPg=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a h1:mEQZbbaBjWyLNy0tmZmgEuQAR8XOQ3hL8GYi3J/NG64=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools/gopls v0.1.4-0.20190729092621-ff9f1409240a h1:JbtfCNgh8ApvwwnASQZ6PGFxua6XD9Oa6Xj3VUf9rjY=
+golang.org/x/tools/gopls v0.1.4-0.20190729092621-ff9f1409240a/go.mod h1:u62zQD3pdNzbxmFIPWkvznqcaE5DWFAf2KUGsCtycPg=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=


### PR DESCRIPTION
* internal/lsp/source: fix renaming of SuggestedFixes in experimental file ff9f1409
* internal/lsp: process configuration per workspace folder fc6e2057
* internal/lsp: compare mod file versions used in imports db2fa46e
* internal/lsp: format files in packages with errors 1bd56024
* internal/import: strings.Trim expects a cutset, not a string 2e34cfcb
* gopls: update x/tools vesion in mod file 8aa4eac1
* internal/lsp: swallow hover error over identifier not found 4e8ec5a3
* internal/lsp: fix lockup for packages with many files 8bb11ff1
* internal/lsp: add an ocagent exporter for the telemetry system e377ae9d
* internal/imports: disable go/packages-incompatible tests 72478f39
* internal/lsp: the json wire format of the open cencus agent 87e92536
* internal/lsp: have tests report a different application name to the main gopls binary 625c92e4
* internal/lsp: new tracing system 38daa656
* internal/imports: save scanned module cache results 82a3ea8a
* go/packages, internal/lsp: modify tests to expose overlays bug c81b7487
* internal/lsp: purge the remains of the xlog system now it is not used 7caf8110
* internal/lsp: convert logging calls 73497f05
* internal/lsp: add a new telemetry based logging system 7ec096a1
* internal/lsp: use a background context for the background worker f2838559
* internal/lsp: fixed broken tracing 128ec6df