### PR TITLE
cmd/govim: switch default hover popup to place above-and-to-the-right

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -139,8 +139,8 @@ func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface
 		opts["line"] = line + int64(vpos.ScreenPos.Row)
 		opts["col"] = col + int64(vpos.ScreenPos.Col)
 	} else {
-		opts["pos"] = "topleft"
-		opts["line"] = vpos.ScreenPos.Row + 1
+		opts["pos"] = "botleft"
+		opts["line"] = vpos.ScreenPos.Row - 1
 		opts["col"] = vpos.ScreenPos.Col
 		opts["mousemoved"] = "any"
 		opts["moved"] = "any"


### PR DESCRIPTION
Following an extremely unscientific poll on Slack, and as part of the
continuing experiment to establish the best out-of-the-box defaults, we
now place hover popups above-and-to-the-right of the cursor.

The main reasons for this change are:

* VSCode and other editors do this
* It's what users (independent of the first point) appear to want/expect
* Such a placement will work better if we are to also show documentation
for completion items (the candidate list appears below-and-to-the-right)

For those people looking to retain the existing behaviour, please now
add the following to your .vimrc:

call govim#config#Set("ExperimentalMouseTriggeredHoverPopupOptions", {
      \ "mousemoved": "any",
      \ "pos": "topleft",
      \ "line": +1,
      \ "col": 0,
      \ "moved": "any",
      \ "wrap": v:false,
      \ "close": "click",
      \ "padding": [0, 1, 0, 1],
      \})

The wiki on vimrc tips and tricks has been updated to reflect this.