### PR TITLE
cmd/govim: expand the set of sensible out-of-the-box defaults

### DIFF
--- a/cmd/govim/config/minimal.vimrc
+++ b/cmd/govim/config/minimal.vimrc
@@ -37,3 +37,23 @@ set balloondelay=250
 " might prefer to instead have the signs shown in the number column; in which
 " case set signcolumn=number (requires Vim >= v8.1.1564)
 set signcolumn=yes
+
+" Suggestion: Turn on syntax highlighting for .go files. You might prefer to
+" turn on syntax highlighting for all files, in which case
+"
+" syntax on
+"
+" will suffice, no autocmd required.
+autocmd! BufEnter,BufNewFile *.go syntax on
+autocmd! BufLeave *.go syntax off
+
+" Suggestion: turn on auto-indenting. If you want closing parentheses, braces
+" etc to be added, https://github.com/jiangmiao/auto-pairs. In future we might
+" include this by default in govim.
+set autoindent
+set smartindent
+filetype indent on
+
+" Suggestion: define sensible backspace behaviour. See :help backspace for
+" more details
+set backspace=2

--- a/cmd/govim/testdata/references.txt
+++ b/cmd/govim/testdata/references.txt
@@ -17,7 +17,7 @@ cmp locations locations.golden
 vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
 vim expr 'bufname(\"\")'
 vim ex 'call cursor(15,1)'
-vim ex 'call feedkeys(\"o\\tfmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
+vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChanged'
 [gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChanged'
 errlogmatch -wait 60s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go


### PR DESCRIPTION
Expand the set of sensible out-of-the-box defaults we recommend in the
minimal .vimrc. In future, as previously discussed, we might want to
make these defaults a part of the govim plugin itself, but for now we
make them as recommendations in the minimal .vimrc

This change includes:

* turning on syntax highlighting for .go files
* turning on smart-autoindent
* setting sensible backspace behaviour

This should give a nicer experience for first-time Vim users.

Fixes #430