### PR TITLE
tests: Fix flaky signs & quickfix config tests

### DIFF
--- a/cmd/govim/testdata/quickfix_config.txt
+++ b/cmd/govim/testdata/quickfix_config.txt
@@ -7,8 +7,10 @@ vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
 cmp errors errors.golden
+[vim] [vim:v8.1.1682] errlogmatch -wait 30s 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 [vim] [vim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [vim] [vim:v8.1.1682] cmp stdout signs.golden
+[gvim] [gvim:v8.1.1682] errlogmatch -wait 30s 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout signs.golden
 errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
@@ -30,7 +32,6 @@ cmp errors empty
 [vim] [vim:v8.1.1682] cmp stdout nosigns.golden
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout nosigns.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 # Enabling quickfix autodiagnostics should give quickfix entries but no signs
 vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 0]'
@@ -46,7 +47,6 @@ cmp errors errors.golden
 [vim] [vim:v8.1.1682] cmp stdout nosigns.golden
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout nosigns.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 ## Enabling signs should place signs
 vim call 'govim#config#Set' '["QuickfixSignsDisable", 0]'
@@ -58,11 +58,12 @@ vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
 cmp errors errors.golden
+[vim] [vim:v8.1.1682] errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
+[gvim] [gvim:v8.1.1682] errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
 [vim] [vim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [vim] [vim:v8.1.1682] cmp stdout signs.golden
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout signs.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 # Signs should not be placed with quickfix autodiagnostics disabled
 vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 1]'
@@ -80,7 +81,12 @@ cmp errors empty
 [vim] [vim:v8.1.1682] cmp stdout nosigns.golden
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout nosigns.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+
+# Make sure that there were only two cases above that placed signs, to avoid flaky false positives
+[vim] [vim:v8.1.1682] errlogmatch -start -count=2 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
+[gvim] [gvim:v8.1.1682] errlogmatch -start -count=2 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
+
+errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/signs.txt
+++ b/cmd/govim/testdata/signs.txt
@@ -39,7 +39,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 vim ex 'call cursor(9,1)'
 vim ex 'call feedkeys(\"2dd\", \"x\")' # Remove line 9 & 10
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_onesign.golden
@@ -49,7 +49,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 # Fixing the last quickfix entry should remove the last sign
 vim call append '[5, "\tvar v string"]'
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_nosign.golden


### PR DESCRIPTION
It's a bit dirty since it leaks details about the implementation, but at this stage it's better than flaky test imho.
The testscripts will now wait for the appropriate calls to pass. 