### PR TITLE
cmd/govim: move BatchStart to avoid panics

### DIFF
--- a/cmd/govim/signs.go
+++ b/cmd/govim/signs.go
@@ -89,7 +89,6 @@ func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
 		bufs = append(bufs, tmp...)
 	}
 
-	v.BatchStart()
 	// Assume all existing signs should be removed, unless found in quickfix entry list
 	for _, placed := range bufs {
 		for _, sign := range placed.Signs {
@@ -130,6 +129,7 @@ func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
 		}
 	}
 
+	v.BatchStart()
 	if len(place) > 0 {
 		placeList := make([]placeDict, len(place))
 		// Use insert order as index to avoid sorting


### PR DESCRIPTION
This PR move a `BatchStart()`-call to avoid calling non-batch functions during a batch.
I've seen a couple of panics that I think will be fixed with this PR.