### PR TITLE
cmd/govim: fix flake in goimports testscript

### DIFF
--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -31,7 +31,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 # Format on save (bad syntax)
 cp file.go.bad file.go
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","setqflist".*'
+errlogmatch -wait 30s -start -count=5 'sendJSONMsg: \[0,\[\d+,"call","setqflist".*'
 vim ex 'w'
 cmp file.go file.go.bad
 vim expr 'getqflist()'


### PR DESCRIPTION
The goimports test sometimes matches an earlier entry when looking for `setfqlist`, this PR will specify that it should match the 5th occasion by adding `-start -count=5`.

Fixes #419 