### PR TITLE
cmd/govim: fix setting GOBIN during install

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -316,17 +316,11 @@ function s:install(force)
   if a:force || $GOVIM_ALWAYS_INSTALL == "true" || !filereadable(targetdir."govim") || !filereadable(targetdir."gopls")
     echom "Installing govim and gopls"
     call feedkeys(" ") " to prevent press ENTER to continue
-    let oldgobin = $GOBIN
-    let oldgomod = $GO111MODULE
-    let $GO111MODULE = "on"
-    let $GOBIN = targetdir
     " TODO make work on Windows
-    let install = system("go install github.com/myitcv/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
+    let install = system("GO111MODULE=on GOBIN=".shellescape(targetdir)." go install github.com/myitcv/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
     if v:shell_error
       throw install
     endif
-    let $GOBIN = oldgobin
-    let $GO111MODULE=oldgomod
   endif
   execute "cd ".oldpath
   return targetdir


### PR DESCRIPTION
### What
Move the GOBIN and GO111MODULE environment variable sets into the system call instead of setting them in VIMs shell.

### Why
On my system setting GOBIN in VIMs shell then calling system is still resulting in the shell run by system having the GOBIN that's defined in my own environment. GOBIN is defined in my shell rc file so it's possible when system is running the command it's starting a new shell which is setting GOBIN again.

This install command should make less assumptions about the shell underneath VIM and moving the environment variables into the system call makes less since it overrides the variables for that single line being executed rather than changing it for the VIM shell.

Fixes #164 