### PR TITLE
test: flake fixed in signs testscript

### DIFF
--- a/cmd/govim/testdata/signs.txt
+++ b/cmd/govim/testdata/signs.txt
@@ -9,7 +9,7 @@
 [gvim] [!gvim:v8.1.1682] skip
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
 
 # Assert that the error sign is defined
 vim -indent expr 'sign_getdefined()'
@@ -28,6 +28,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 vim ex 'call cursor(6,36)'
 vim ex 'call feedkeys(\"3x\", \"x\")' # Remove "i, " from Printf-line
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
+[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
@@ -39,6 +40,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 vim ex 'call cursor(9,1)'
 vim ex 'call feedkeys(\"2dd\", \"x\")' # Remove line 9 & 10
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
+[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
@@ -49,6 +51,7 @@ errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v,
 # Fixing the last quickfix entry should remove the last sign
 vim call append '[5, "\tvar v string"]'
 [vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
+[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+


### PR DESCRIPTION
This PR fixes flakes in `testdata/signs.txt`. I've observed that the first `sign_getplaced()` can be called before the signs were placed.

Waiting for the actual placelist call instead of the diagnostics callback fixes it.