### PR TITLE
plugin: govim.vim: fix env var

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -317,7 +317,7 @@ function s:install(force)
     echom "Installing govim and gopls"
     call feedkeys(" ") " to prevent press ENTER to continue
     " TODO make work on Windows
-    let install = system("GO111MODULE=on GOBIN=".shellescape(targetdir)." go install github.com/myitcv/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
+    let install = system("env GO111MODULE=on GOBIN=".shellescape(targetdir)." go install github.com/myitcv/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
     if v:shell_error
       throw install
     endif


### PR DESCRIPTION
The `MYVAR=myvalue command ...` syntax is a bash-ism, and incompatible with other shells, e.g. [fish](https://fishshell.com). With the code as-is, installing govim using fish fails with the unfortunately cryptic

```
Installing govim and gopls
Error detected while processing function <SNR>20_install:
line   15:
E605: Exception not caught:
Error detected while processing /Users/pbourgon/.vim/pack/plugins/start/govim/plugin/govim.vim:
line  334:
E171: Missing :endif
Press ENTER or type command to continue
```

I've updated to the more widely compatible alternative, `env MYVAR=myvalue command ...`.