### PR TITLE
cmd/govim: add separate watcher for darwin

### DIFF
--- a/cmd/govim/internal/fswatcher/fswatcher.go
+++ b/cmd/govim/internal/fswatcher/fswatcher.go
@@ -1,0 +1,17 @@
+package fswatcher
+
+type FSWatcher struct {
+	*fswatcher // os specific
+}
+
+type Event struct {
+	Path string
+	Op   Op
+}
+
+type Op string
+
+const (
+	OpChanged Op = "changed"
+	OpRemoved Op = "removed"
+)

--- a/cmd/govim/internal/fswatcher/os_darwin.go
+++ b/cmd/govim/internal/fswatcher/os_darwin.go
@@ -1,0 +1,91 @@
+// +build darwin
+
+package fswatcher
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsevents"
+	"gopkg.in/tomb.v2"
+)
+
+const fRemoved = fsevents.ItemRemoved | fsevents.ItemRenamed
+const fChanged = fsevents.ItemCreated | fsevents.ItemModified | fsevents.ItemChangeOwner
+
+type fswatcher struct {
+	eventCh chan Event
+	es      *fsevents.EventStream
+}
+
+func New(gomodpath string, tomb *tomb.Tomb) (*FSWatcher, error) {
+	dirpath := filepath.Dir(gomodpath)
+	dev, err := fsevents.DeviceForPath(dirpath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve device for path %v: %v", dirpath, err)
+	}
+
+	es := &fsevents.EventStream{
+		Paths:   []string{dirpath},
+		Latency: 200 * time.Millisecond,
+		Device:  dev,
+		Flags:   fsevents.FileEvents | fsevents.WatchRoot,
+	}
+
+	es.Start()
+
+	// fsevents returns paths relative to device root so we need
+	// to figure out the actual mount point
+	mountPoint, err := filepath.Abs(dirpath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for mountPoint != string(os.PathSeparator) {
+		parent := filepath.Dir(mountPoint)
+		pDev, err := fsevents.DeviceForPath(parent)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if pDev != dev {
+			break
+		}
+		mountPoint = parent
+	}
+
+	eventCh := make(chan Event)
+	tomb.Go(func() error {
+		for {
+			events, ok := <-es.Events
+			if !ok {
+				break
+			}
+			for i := range events {
+				event := events[i]
+				path := filepath.Join(mountPoint, event.Path)
+				switch {
+				case event.Flags&fRemoved > 0:
+					eventCh <- Event{path, OpRemoved}
+				case event.Flags&fChanged > 0:
+					eventCh <- Event{path, OpChanged}
+				}
+			}
+		}
+		close(eventCh)
+		return nil
+	})
+
+	return &FSWatcher{&fswatcher{eventCh, es}}, nil
+}
+
+func (w *fswatcher) Add(path string) error    { return nil }
+func (w *fswatcher) Remove(path string) error { return nil }
+func (w *fswatcher) Close() error {
+	w.es.Stop()
+	return nil
+}
+func (w *fswatcher) Events() chan Event { return w.eventCh }
+func (w *fswatcher) Errors() chan error { return make(chan error) }

--- a/cmd/govim/internal/fswatcher/os_others.go
+++ b/cmd/govim/internal/fswatcher/os_others.go
@@ -1,0 +1,67 @@
+// +build !darwin
+
+package fswatcher
+
+import (
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+	"gopkg.in/tomb.v2"
+)
+
+type fswatcher struct {
+	eventCh chan Event
+	errCh   chan error
+	mw      *fsnotify.Watcher
+}
+
+func New(gomodpath string, tomb *tomb.Tomb) (*FSWatcher, error) {
+	mw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new watcher: %v", err)
+	}
+
+	eventCh := make(chan Event)
+	tomb.Go(func() error {
+		for {
+			e, ok := <-mw.Events
+			if !ok {
+				break
+			}
+			switch e.Op {
+			case fsnotify.Rename, fsnotify.Remove:
+				eventCh <- Event{e.Name, OpRemoved}
+			case fsnotify.Create, fsnotify.Chmod, fsnotify.Write:
+				eventCh <- Event{e.Name, OpChanged}
+			}
+		}
+		close(eventCh)
+		return nil
+	})
+
+	return &FSWatcher{&fswatcher{
+		eventCh: eventCh,
+		errCh:   mw.Errors,
+		mw:      mw,
+	}}, nil
+}
+
+func (w *fswatcher) Add(path string) error {
+	return w.mw.Add(path)
+}
+
+func (w *fswatcher) Remove(path string) error {
+	return w.mw.Remove(path)
+}
+
+func (w *fswatcher) Close() error {
+	return w.mw.Close()
+}
+
+func (w *fswatcher) Events() chan Event {
+	return w.eventCh
+}
+
+func (w *fswatcher) Errors() chan error {
+	return w.errCh
+}

--- a/cmd/govim/testdata/watcher.txt
+++ b/cmd/govim/testdata/watcher.txt
@@ -16,6 +16,8 @@ vim ex 'cclose'
 cmp errors errors.empty
 cmp main.go main.go.golden
 
+skip 'Temporary disabled due to https://github.com/myitcv/govim/issues/492'
+
 # New package, note that this is currently handled by a separate lib in darwin
 vim ex 'call cursor(7,1)'
 vim ex 'call feedkeys(\"ifmt.Println(foo.Bar)\n\\<ESC>\",\"x\")'

--- a/cmd/govim/testdata/watcher.txt
+++ b/cmd/govim/testdata/watcher.txt
@@ -1,0 +1,67 @@
+# Test that the file watcher picks up file changes that occurs outside the editor
+
+# New file in the same package
+vim ex 'e main.go'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+cp const.go.orig const.go
+errlogmatch -wait 30s '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/const.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
+vim ex 'call cursor(6,16)'
+vim ex 'call feedkeys(\"iConst2\\<ESC>\", \"x\")'
+vim ex 'w'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim ex 'copen'
+vim ex 'w errors'
+vim ex 'cclose'
+cmp errors errors.empty
+cmp main.go main.go.golden
+
+# New package, note that this is currently handled by a separate lib in darwin
+vim ex 'call cursor(7,1)'
+vim ex 'call feedkeys(\"ifmt.Println(foo.Bar)\n\\<ESC>\",\"x\")'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+mkdir foo
+cp foo_foo.go.orig foo/foo.go
+errlogmatch -wait 30s '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/foo/foo.go
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/foo/foo.go
+vim ex 'w'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim ex 'copen'
+vim ex 'w errors'
+vim ex 'cclose'
+cmp errors errors.empty
+
+# No warnings or errors during the test
+errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println()
+}
+-- const.go.orig --
+package main
+
+const (
+	Const1 = 1
+	Const2 = 2
+)
+-- main.go.golden --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(Const2)
+}
+-- foo_foo.go.orig --
+package foo
+
+const Bar = 1
+-- errors.empty --

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/fsnotify/fsevents v0.1.1
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/kr/pretty v0.1.0
 	github.com/kr/pty v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
+github.com/fsnotify/fsevents v0.1.1 h1:/125uxJvvoSDDBPen6yUZbil8J9ydKZnnl3TWWmvnkw=
+github.com/fsnotify/fsevents v0.1.1/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
@@ -37,6 +39,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 h1:cGjJzUd8RgBw428LXP65YXni0aiGNA4Bl+ls8SmLOm8=
 golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
As the current filesystem watcher is using `fsnotify/fsnotify` and opens up loads of files this PR will change the macOS implementation to use `fsnotify/fsevents` instead.

Pro's about this is that `fsevents` watches recursively so the implementation is fairly simple.

Con's about this is that it doesn't support module directories that spawns over several devices as the device must be specified when the watcher is created. There is an open issue, https://github.com/fsnotify/fsevents/issues/36, that prevents adding multiple paths.

I guess we could add several watchers to handle that case, but I'm not sure it's worth it as the watchers should go away as soon as they are added to gopls anyway.

Another option could be to allow macOS users to use the "legacy fsnotifiy" with an env var, in case they run into problems with fsevents.

Closes #464 
