### PR TITLE
test: fix false positives in testscripts

### DIFF
--- a/cmd/govim/testdata/bad_complete.txt
+++ b/cmd/govim/testdata/bad_complete.txt
@@ -7,7 +7,7 @@
 vim ex 'e main.go'
 vim ex 'call cursor(5,1)'
 vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\", \"x\")'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/command.txt
+++ b/cmd/govim/testdata/command.txt
@@ -7,7 +7,7 @@ vim ex 'GOVIMHello'
 vim expr 'v:statusmsg'
 stdout '^\Q"Hello from command"\E$'
 ! stderr .+
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 # Test that we can pass args
 vim ex 'GOVIMHello goodbye'
@@ -16,4 +16,4 @@ vim ex 'GOVIMHello goodbye'
 vim expr 'v:statusmsg'
 stdout '^\Q"Hello from command; special note: goodbye"\E$'
 ! stderr .+
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'

--- a/cmd/govim/testdata/complete.txt
+++ b/cmd/govim/testdata/complete.txt
@@ -7,7 +7,7 @@ vim ex 'call cursor(11,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'
 cmp main.go main.go.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/complete_watched.txt
+++ b/cmd/govim/testdata/complete_watched.txt
@@ -12,7 +12,7 @@ vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'
 cmp main.go main.go.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/format_on_save_none.txt
+++ b/cmd/govim/testdata/format_on_save_none.txt
@@ -5,7 +5,7 @@ vim call 'govim#config#Set' '["FormatOnSave", ""]'
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.orig
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/function.txt
+++ b/cmd/govim/testdata/function.txt
@@ -3,7 +3,7 @@
 vim normal '\"=GOVIMHello()\u000dp'
 vim ex 'w test'
 cmp test test.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- test.golden --
 Hello from function

--- a/cmd/govim/testdata/function_hover.txt
+++ b/cmd/govim/testdata/function_hover.txt
@@ -14,7 +14,7 @@ vim expr 'GOVIMHover()'
 [vim:v8.1.1649] vim -stringout expr 'GOVIM_internal_DumpPopups()'
 [vim:v8.1.1649] cmp stdout popup.golden
 [vim:v8.1.1649] ! stderr .+
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/go_to_def_newtab.txt
+++ b/cmd/govim/testdata/go_to_def_newtab.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["leaf",1001]\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_same_file.txt
+++ b/cmd/govim/testdata/go_to_def_same_file.txt
@@ -12,7 +12,7 @@ vim expr 'bufname(\"\")'
 stdout '^\Q"'$WORK'/p.go"\E$'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[8,7]\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_split.txt
+++ b/cmd/govim/testdata/go_to_def_split.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["col",[["leaf",1000],["leaf",1001]]]\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_useopen.txt
+++ b/cmd/govim/testdata/go_to_def_useopen.txt
@@ -18,7 +18,7 @@ vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_usetab.txt
+++ b/cmd/govim/testdata/go_to_def_usetab.txt
@@ -21,7 +21,7 @@ vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/go_to_def_vsplit.txt
+++ b/cmd/govim/testdata/go_to_def_vsplit.txt
@@ -17,7 +17,7 @@ vim expr 'string([getcurpos()[1], getcurpos()[2]])'
 stdout '^\Q"[3, 7]"\E$'
 vim expr 'winlayout()'
 stdout '^\Q["row",[["leaf",1000],["leaf",1001]]]\E$'
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/gofmt.txt
+++ b/cmd/govim/testdata/gofmt.txt
@@ -22,7 +22,7 @@ vim ex 'w'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 cmp file.go file.go.gofmt
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 # Format on save (bad syntax)
 cp file.go.bad file.go
@@ -34,7 +34,7 @@ vim expr 'getqflist()'
 stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
 ! stderr .+
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -46,7 +46,7 @@ vim ex '3,5GOVIMGoFmt'
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -26,7 +26,7 @@ vim ex 'w'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 cmp file.go file.go.goimports
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 # Format on save (bad syntax)
 cp file.go.bad file.go
@@ -38,7 +38,7 @@ vim expr 'getqflist()'
 stdout '^\Q[{"bufnr":1,"col":1,"lnum":3,"module":"","nr":0,"pattern":"","text":"expected declaration, found blah","type":"","valid":1,"vcol":0}]\E$'
 ! stderr .+
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -49,7 +49,7 @@ vim ex '3,5GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp file.go file.go.goimports
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/hover.txt
+++ b/cmd/govim/testdata/hover.txt
@@ -13,7 +13,7 @@ sleep 500ms
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout popup.golden
 ! stderr .+
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/mapping_defaults_go_to_def.txt
+++ b/cmd/govim/testdata/mapping_defaults_go_to_def.txt
@@ -63,7 +63,7 @@ vim ex 'call feedkeys(\"g\\<RightMouse>\", \"x\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[3,15]\E$'
 
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com/p

--- a/cmd/govim/testdata/quickfix.txt
+++ b/cmd/govim/testdata/quickfix.txt
@@ -5,7 +5,7 @@ errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnostics
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/quickfix_config.txt
+++ b/cmd/govim/testdata/quickfix_config.txt
@@ -13,7 +13,7 @@ cmp errors errors.golden
 [gvim] [gvim:v8.1.1682] errlogmatch -wait 30s 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 [gvim] [gvim:v8.1.1682] vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 [gvim] [gvim:v8.1.1682] cmp stdout signs.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 # There must be no quickfix entries or signs when both are explicitly disabled
 vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 1]'
@@ -86,7 +86,7 @@ cmp errors empty
 [vim] [vim:v8.1.1682] errlogmatch -start -count=2 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 [gvim] [gvim:v8.1.1682] errlogmatch -start -count=2 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 
-errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/quickfix_eof.txt
+++ b/cmd/govim/testdata/quickfix_eof.txt
@@ -6,7 +6,7 @@ errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnostics
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/references.txt
+++ b/cmd/govim/testdata/references.txt
@@ -33,7 +33,7 @@ vim ex 'w errors'
 cmp errors errors.golden
 
 # Check for errors
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
 module mod.com

--- a/cmd/govim/testdata/signs.txt
+++ b/cmd/govim/testdata/signs.txt
@@ -21,7 +21,7 @@ cmp stdout defined.golden
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_openfile.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 
 # Removing one of the two quickfix entires on one line shouldn't remove the sign
@@ -33,7 +33,7 @@ errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnostics
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_openfile.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 
 # Removing lines should also remove the signs
@@ -45,7 +45,7 @@ errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacel
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_onesign.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 
 # Fixing the last quickfix entry should remove the last sign
@@ -56,7 +56,7 @@ errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacel
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_nosign.golden
-errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:%v, Message:".*'
+errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 
 -- go.mod --


### PR DESCRIPTION
Most of the testscript files checks for errors by matching a `LogMessage callback:` string. It does however contain `%v` so will never match any errors.

This change will make them check for `LogMessage` callbacks of type 1 or 2 (i.e. [warnings or errors](https://microsoft.github.io/language-server-protocol/specification#window_showMessage)) instead.