### PR TITLE
cmd/govim: do not create a popup if there is a zero Hover response

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -112,9 +112,9 @@ func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface
 	}
 	hovRes, err := v.server.Hover(context.Background(), params)
 	if err != nil {
-		// TODO we should only get an error when there is an error, rather than
-		// nothing to display: https://github.com/golang/go/issues/32971
-		v.Logf("failed to get hover details: %v", err)
+		return "", fmt.Errorf("failed to get hover details: %v", err)
+	}
+	if *hovRes == (protocol.Hover{}) {
 		return "", nil
 	}
 	msg := strings.TrimSpace(hovRes.Contents.Value)


### PR DESCRIPTION
cmd/govim: do not create a popup if there is a zero Hover response

Currently, we show a popup in the case there is no error in the call to
Hover. However, we do not check that there is actually anthing to show.

Following https://go-review.googlesource.com/c/tools/+/186997/, the
Hover LSP method swallows errors where the user hovered over an area
where there is no information. So now we get back nil errors and empty
Hover{} values where before we got an error (which we simply logged).

Correct this by only showing a popup in case we have a non-zero value
Hover{}.